### PR TITLE
Add plot subcommand for CNV plots.

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,6 +28,7 @@ use crate::grammar;
 use crate::model::modes::generic::{FlatPrior, GenericModelBuilder};
 use crate::model::sample::{estimate_alignment_properties, SampleBuilder};
 use crate::model::{Contamination, VariantType};
+use crate::plotting;
 use crate::testcase::TestcaseBuilder;
 use crate::SimpleEvent;
 
@@ -61,6 +62,24 @@ pub enum Varlociraptor {
         about = "Decode PHRED-scaled values to human readable probabilities."
     )]
     DecodePHRED,
+    #[structopt(name = "plot", about = "Plot stuff.")]
+    Plot {
+        #[structopt(subcommand)]
+        kind: PlotKind,
+    },
+}
+
+#[derive(Debug, StructOpt, Serialize, Deserialize, Clone)]
+pub enum PlotKind {
+    #[structopt(
+        raw(setting = "structopt::clap::AppSettings::ColoredHelp"),
+        name = "cnvs",
+        about = "Plot CNVs."
+    )]
+    CNVs {
+        #[structopt(parse(from_os_str), help = "Calls from `varlociraptor call cnvs ...`.")]
+        cnvfile: Option<PathBuf>,
+    },
 }
 
 #[derive(Debug, StructOpt, Serialize, Deserialize, Clone)]
@@ -675,6 +694,11 @@ pub fn run(opt: Varlociraptor) -> Result<(), Box<Error>> {
         Varlociraptor::DecodePHRED => {
             conversion::decode_phred::decode_phred()?;
         }
+        Varlociraptor::Plot { kind } => match kind {
+            PlotKind::CNVs { cnvfile } => {
+                plotting::cnv::plot::<&PathBuf>(cnvfile.as_ref())?;
+            }
+        },
     }
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub mod estimation;
 pub mod filtration;
 pub mod grammar;
 pub mod model;
+pub mod plotting;
 pub mod testcase;
 pub mod utils;
 

--- a/src/plotting/cnv.rs
+++ b/src/plotting/cnv.rs
@@ -1,0 +1,85 @@
+use std::error::Error;
+use std::fs;
+use std::path::Path;
+
+use rust_htslib::bcf;
+use rust_htslib::bcf::{Read, Record};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use serde_json::value::Value::Object;
+
+#[derive(Serialize, Deserialize)]
+struct CNRecord {
+    start: u32,
+    end: u32,
+    copynumber: u32,
+    subclone_fraction: f32,
+}
+
+/// Plot copynumber vs genomic position (in bp), with subclone fraction as color dimension.
+///
+/// Uses the vega-lite v3 json scheme.
+/// Currently, chromosomes are divided using vertical lines, with genomic positions w.r.t hg38.
+pub fn plot<P: AsRef<Path>>(cnv_calls: Option<P>) -> Result<(), Box<Error>> {
+    let mut inbcf_reader = match cnv_calls {
+        Some(p) => bcf::Reader::from_path(p)?,
+        None => bcf::Reader::from_stdin()?,
+    };
+
+    let mut cumulative_pos = 0;
+    let mut last_record: Option<Record> = None;
+    let mut records: Vec<CNRecord> = Vec::new();
+
+    for record in inbcf_reader.records() {
+        let mut record = record?;
+        if let Some(mut previous_record) = last_record {
+            if record.rid() != previous_record.rid() {
+                cumulative_pos += previous_record.pos();
+            } else {
+                records.push(CNRecord {
+                    start: previous_record
+                        .info(b"END")
+                        .integer()?
+                        .expect("Failed reading info tag 'END'")[0]
+                        as u32
+                        + cumulative_pos,
+                    end: record.pos() + cumulative_pos,
+                    copynumber: 2,
+                    subclone_fraction: 0f32,
+                });
+            }
+        }
+        let copynumber = record
+            .info(b"CN")
+            .integer()?
+            .expect("Failed reading info tag 'CN'")[0];
+        let subclone_fraction = record
+            .info(b"VAF")
+            .float()?
+            .expect("Failed reading info tag 'VAF'")[0];
+        let start = record.pos();
+        let end = record
+            .info(b"END")
+            .integer()?
+            .expect("Failed reading info tag 'END'")[0] as u32;
+        records.push(CNRecord {
+            start: start + cumulative_pos,
+            end: end + cumulative_pos,
+            copynumber: copynumber as u32,
+            subclone_fraction,
+        });
+        last_record = Some(record);
+    }
+
+    // read vega-lite plot json and replace data entry for "copynumbers" with actual values.
+    let mut blueprint =
+        serde_json::from_str(&fs::read_to_string(&"templates/blueprint_plot_cnv.json")?)?;
+    if let Object(ref mut blueprint) = blueprint {
+        let datasets = &mut blueprint["datasets"];
+        if let Object(ref mut datasets) = datasets {
+            datasets.insert("copynumbers".to_owned(), json!(records));
+        }
+        println!("{}", serde_json::to_string_pretty(blueprint)?);
+    }
+    Ok(())
+}

--- a/src/plotting/mod.rs
+++ b/src/plotting/mod.rs
@@ -1,0 +1,6 @@
+// Copyright 2016-2019 Johannes Köster, David Lähnemann.
+// Licensed under the GNU GPLv3 license (https://opensource.org/licenses/GPL-3.0)
+// This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub mod cnv;

--- a/templates/blueprint_plot_cnv.json
+++ b/templates/blueprint_plot_cnv.json
@@ -1,0 +1,61 @@
+{ 
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "width": 1200,
+    "height": 700,
+    "layer": [
+                {
+            "data": {
+                "name": "chromsizes"
+            },
+            "mark": {
+                "type": "rule"
+            },
+
+            "encoding": {
+                "x": {
+                    "field": "data", "type": "quantitative",
+                    "axis": {
+                        "grid": false
+                    }
+                },
+                "color": {"value": "#66333366"},
+                "size": {"value": 1}
+            }
+        },
+        {
+            "data": {
+                "name": "copynumbers"
+            },
+            "mark": {
+                "type": "rule",
+                "strokeWidth": 10,
+                "strokeCap": "square"
+            },
+
+            "encoding": {
+                "x": {
+                    "field": "start", "type": "quantitative",
+                    "title": "Position on genome (bp)"
+                },
+                "x2": {"field": "end"},
+                "y": {
+                    "field": "copynumber", "type": "quantitative",
+                    "title": "Copynumber"
+                },
+                "color": {
+                    "field": "subclone_fraction", "type": "quantitative",
+                    "title": "Subclonal fraction"
+                }
+            } 
+        }
+  ],
+  "datasets": {
+       "chromsizes": [248956422,  491149951,  689445510,  879660065, 1061198324,
+                      1232004303, 1391350276, 1536488912, 1674883629, 1808681051,
+                      1943767673, 2077042982, 2191407310, 2298451028, 2400442217,
+                      2490780562, 2574038003, 2654411288, 2713028904, 2777473071,
+                      2824183054, 2875001522, 3031042417, 3088269832],
+       "chromosomes": ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "X", "Y"],
+       "copynumbers": []
+     }
+}


### PR DESCRIPTION
This PR adds a `plot` subcommand to varlociraptor, basically simply parsing the CNV calls into the respective JSON fields required for vega-lite.
This approach uses a blueprint json file into which the values are inserted.
Output is written to stdout at the moment (there is no --output parameter, yet).