### PR TITLE
State scale (PHRED / linear) on INFO fields in bcf header for event tags.

### DIFF
--- a/src/call.rs
+++ b/src/call.rs
@@ -182,7 +182,7 @@ where
             header.push_record(
                 format!(
                     "##INFO=<ID={},Number=A,Type=Float,\
-                     Description=\"Posterior probability for event {}\">",
+                     Description=\"Posterior probability for event {} (PHRED)\">",
                     event_tag_name(event),
                     event
                 )

--- a/src/conversion/decode_phred.rs
+++ b/src/conversion/decode_phred.rs
@@ -15,9 +15,13 @@ pub fn decode_phred() -> Result<(), Box<Error>> {
         .into_iter()
         .filter_map(|rec| {
             if let bcf::header::HeaderRecord::Info { values, .. } = rec {
-                let id = values.get("ID").unwrap();
+                let id = values.get("ID").unwrap().clone();
                 if id.starts_with("PROB_") {
-                    return Some(id.clone().into_bytes());
+                    let description = values.get("Description").unwrap().clone();
+                    // only consider PHRED scaled probabilities
+                    if description.ends_with("(PHRED)") {
+                        return Some((id, description));
+                    }
                 }
             }
             None
@@ -25,18 +29,31 @@ pub fn decode_phred() -> Result<(), Box<Error>> {
         .collect_vec();
 
     // setup output file
-    let header = bcf::Header::from_template(inbcf.header());
+    let mut header = bcf::Header::from_template(inbcf.header());
+    for (id, description) in &tags {
+        header.remove_info(&id.clone().into_bytes());
+        let description = description.replace("(PHRED)", "(linear)");
+        header.push_record(
+            format!(
+                "##INFO=<ID={},Number=A,Type=Float,\
+                 Description=\"{}\">",
+                id, description
+            )
+            .as_bytes(),
+        );
+    }
     let mut outbcf = bcf::Writer::from_stdout(&header, false, false)?;
 
     for record in inbcf.records() {
         let mut record = record?;
-        for tag in &tags {
-            if let Some(values) = record.info(tag).float()? {
+        for (tag, _desc) in &tags {
+            let id = &tag.clone().into_bytes();
+            if let Some(values) = record.info(id).float()? {
                 let converted = values
                     .iter()
                     .map(|v| *Prob::from(PHREDProb(*v as f64)) as f32)
                     .collect_vec();
-                record.push_info_float(tag, &converted)?;
+                record.push_info_float(&id, &converted)?;
             }
         }
         outbcf.write(&record)?;

--- a/src/filtration/fdr.rs
+++ b/src/filtration/fdr.rs
@@ -19,6 +19,7 @@ use rust_htslib::bcf::Read;
 use crate::model;
 use crate::utils;
 use crate::Event;
+use crate::utils::is_phred_scaled;
 
 /// Print thresholds to control FDR of given calls at multiple levels.
 ///
@@ -44,6 +45,10 @@ where
 {
     // first pass on bcf file
     let mut inbcf_reader = bcf::Reader::from_path(&inbcf)?;
+
+    if !is_phred_scaled(&inbcf_reader) {
+        panic!("Event probabilities are not PHRED scaled, aborting.")
+    }
 
     // setup output file
     let header = bcf::Header::from_template(inbcf_reader.header());

--- a/src/filtration/posterior_odds.rs
+++ b/src/filtration/posterior_odds.rs
@@ -11,6 +11,7 @@ use std::error::Error;
 use std::path::Path;
 
 use crate::utils;
+use crate::utils::{get_event_tags, is_phred_scaled};
 use crate::Event;
 
 /// Filter calls by posterior odds against the given events.
@@ -31,21 +32,15 @@ where
         None => bcf::Reader::from_stdin()?,
     };
 
-    let other_event_tags = inbcf_reader
-        .header()
-        .header_records()
+    if !is_phred_scaled(&inbcf_reader) {
+        panic!("Event probabilities are not PHRED scaled, aborting.")
+    }
+
+    let other_event_tags = get_event_tags(&inbcf_reader);
+    let other_event_tags = other_event_tags
         .iter()
-        .filter_map(|rec| {
-            if let bcf::header::HeaderRecord::Info { ref values, .. } = rec {
-                if values["ID"].starts_with("PROB_") {
-                    Some(values["ID"].clone())
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        })
+        .map(|(tag, _desc)| tag)
+        .cloned()
         .collect_vec();
     let event_tags = utils::events_to_tags(events);
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -596,7 +596,8 @@ impl Overlap {
 pub fn is_phred_scaled(inbcf: &bcf::Reader) -> bool {
     get_event_tags(inbcf)
         .iter()
-        .all(|(_, d)| d.ends_with("(PHRED)"))
+        // check for missing closing parenthesis for backward compatibility
+        .all(|(_, d)| d.ends_with("(PHRED)") || !d.ends_with(")"))
 }
 
 /// Returns (ID, Description) for each PROB_{event} INFO tag

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -611,6 +611,7 @@ pub fn get_event_tags(inbcf: &bcf::Reader) -> Vec<(String, String)> {
                 let id = values["ID"].clone();
                 if id.starts_with("PROB_") {
                     let description = values["Description"].clone();
+                    let description = description.trim_matches('"').into();
                     return Some((id, description));
                 }
             }


### PR DESCRIPTION
  - `decode-phred` converts from default PHRED scaled probabilities to non scaled unit probabilities but adds no information whether values are scaled or not, possibly leading to confusion
  - the filtration tools, too, expect PHRED scaled quality values
  - this PR appends either (PHRED) or (linear) to the description field of any event tag in the bcf header, e.g.:
    -  `##INFO=<ID=PROB_GERMLINE_HET,Number=A,Type=Float,Description=Posterior probability for event germline_het>`
becomes
`##INFO=<ID=PROB_GERMLINE_HET,Number=A,Type=Float,Description=Posterior probability for event germline_het (PHRED)>` by default with this PR
    -  running `decode-phred` leads to
`##INFO=<ID=PROB_GERMLINE_HET,Number=A,Type=Float,Description=Posterior probability for event germline_het (PHRED)>` (also without the trailing `(PHRED)` for backward compatibility)
becoming
`##INFO=<ID=PROB_GERMLINE_HET,Number=A,Type=Float,Description=Posterior probability for event germline_het (linear)>`
  - open issues: if changes to the info tags are made (i.e. phred → linear conversion happens), the info tags will change position in the header.