### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -620,7 +620,7 @@ mod tests {
 
         let true_alt_probs = [-0.09, -0.02, -73.09, -16.95, -73.09];
 
-        for (record, true_alt_prob) in records.into_iter().zip(true_alt_probs.into_iter()) {
+        for (record, true_alt_prob) in records.into_iter().zip(true_alt_probs.iter()) {
             let mut record = record.unwrap();
             record.cache_cigar();
             let cigar = record.cigar_cached().unwrap();


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.