### PR TITLE
Generalize bias handling. Add read orientation bias.

### DIFF
--- a/src/calling/variants/calling.rs
+++ b/src/calling/variants/calling.rs
@@ -110,7 +110,11 @@ where
         );
         header.push_record(
             b"##FORMAT=<ID=OBS,Number=A,Type=String,\
-              Description=\"Posterior odds for alt allele of each fragment as Kass Raftery \
+              Description=\"Summary of observations. Each entry is encoded as CBTSO, with C being a count, \
+              B being the posterior odds for the alt allele (see below), T being the type of alignment, encoded \
+              as s=single end and p=paired end, S being the strand that supports the observation (+, -, or * for both), \
+              and O being the read orientation (> = F1R2, < = F2R1, * = unknown, ! = non standard, e.g. R1F2). \
+              Posterior odds for alt allele of each fragment are given as Kass Raftery \
               scores: N=none, B=barely, P=positive, S=strong, V=very strong (lower case if \
               probability for correct mapping of fragment is <95%)\">",
         );

--- a/src/calling/variants/calling.rs
+++ b/src/calling/variants/calling.rs
@@ -28,7 +28,7 @@ use crate::variants::model::modes::generic::{
 };
 use crate::variants::model::Contamination;
 use crate::variants::model::{
-    bias::strand_bias::StrandBias, bias::Biases, bias::BiasesBuilder, AlleleFreq,
+    bias::strand_bias::StrandBias, bias::read_orientation_bias::ReadOrientationBias, bias::Biases, bias::BiasesBuilder, AlleleFreq,
 };
 use crate::variants::types::breakends::BreakendIndex;
 

--- a/src/calling/variants/mod.rs
+++ b/src/calling/variants/mod.rs
@@ -23,7 +23,7 @@ use crate::utils;
 use crate::variants::evidence::observation::expected_depth;
 use crate::variants::evidence::observation::Observation;
 use crate::variants::model;
-use crate::variants::model::{AlleleFreq, StrandBias};
+use crate::variants::model::{bias::Biases, bias::StrandBias, AlleleFreq};
 
 pub(crate) use crate::calling::variants::calling::CallerBuilder;
 
@@ -142,8 +142,9 @@ impl Call {
                     .iter()
                     .enumerate()
                 {
+                    // TODO add other biases once implemented
                     strand_bias.entry(i).or_insert_with(Vec::new).push(
-                        match sample_info.strand_bias {
+                        match sample_info.biases.strand_bias() {
                             StrandBias::None => '.',
                             StrandBias::Forward => '+',
                             StrandBias::Reverse => '-',
@@ -374,12 +375,12 @@ impl VariantBuilder {
     }
 }
 
-#[derive(Default, Clone, Debug, Builder)]
+#[derive(Clone, Debug, Builder)]
 pub(crate) struct SampleInfo {
     allelefreq_estimate: AlleleFreq,
     #[builder(default = "Vec::new()")]
     observations: Vec<Observation>,
-    strand_bias: StrandBias,
+    biases: Biases,
 }
 
 /// Wrapper for comparing alleles for compatibility in BCF files.

--- a/src/calling/variants/mod.rs
+++ b/src/calling/variants/mod.rs
@@ -21,7 +21,7 @@ use vec_map::VecMap;
 use crate::calling::variants::preprocessing::write_observations;
 use crate::utils;
 use crate::variants::evidence::observation::expected_depth;
-use crate::variants::evidence::observation::Observation;
+use crate::variants::evidence::observation::{Observation, Strand};
 use crate::variants::model;
 use crate::variants::model::{bias::Biases, bias::StrandBias, AlleleFreq};
 
@@ -174,10 +174,10 @@ impl Call {
                                     } else {
                                         score.to_ascii_uppercase()
                                     },
-                                    match (obs.forward_strand, obs.reverse_strand) {
-                                        (true, true) => '*',
-                                        (false, true) => '-',
-                                        (true, false) => '+',
+                                    match obs.strand {
+                                        Strand::Both => '*',
+                                        Strand::Reverse => '-',
+                                        Strand::Forward => '+',
                                         _ => panic!("bug: unknown strandedness"),
                                     }
                                 )

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -10,7 +10,7 @@ use std::ops::Deref;
 use std::str;
 
 use anyhow::Result;
-use bio::stats::{bayesian::bayes_factors::evidence::KassRaftery, LogProb, PHREDProb};
+use bio::stats::{bayesian::bayes_factors::evidence::KassRaftery, LogProb, PHREDProb, Prob};
 use counter::Counter;
 use half::f16;
 use itertools::join;
@@ -29,6 +29,10 @@ pub(crate) use collect_variants::collect_variants;
 pub(crate) use worker_pool::worker_pool;
 
 pub(crate) const NUMERICAL_EPSILON: f64 = 1e-3;
+
+lazy_static! {
+    pub(crate) static ref PROB05: LogProb = LogProb::from(Prob(0.5f64));
+}
 
 pub(crate) fn is_sv_bcf(reader: &bcf::Reader) -> bool {
     for rec in reader.header().header_records() {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -31,7 +31,8 @@ pub(crate) use worker_pool::worker_pool;
 pub(crate) const NUMERICAL_EPSILON: f64 = 1e-3;
 
 lazy_static! {
-    pub(crate) static ref PROB05: LogProb = LogProb::from(Prob(0.5f64));
+    pub(crate) static ref PROB_HALF: LogProb = LogProb::from(Prob(0.5f64));
+    pub(crate) static ref PROB_ONE_THIRD: LogProb = LogProb::from(Prob(1.0 / 3.0));
 }
 
 pub(crate) fn is_sv_bcf(reader: &bcf::Reader) -> bool {

--- a/src/variants/evidence/observation.rs
+++ b/src/variants/evidence/observation.rs
@@ -160,7 +160,7 @@ where
                         .prob_ref(allele_support.prob_ref_allele())
                         .prob_sample_alt(self.prob_sample_alt(evidence, alignment_properties))
                         .prob_missed_allele(allele_support.prob_missed_allele())
-                        .prob_overlap(LogProb::ln_zero()) // no double overlap possible
+                        .prob_overlap(LogProb::ln_zero()) // no double overlap possible (TODO: check this!)
                         .strand(allele_support.strand())
                         .read_orientation(evidence.read_orientation())
                         .build()

--- a/src/variants/model/bias/mod.rs
+++ b/src/variants/model/bias/mod.rs
@@ -5,8 +5,10 @@ use bio::stats::probs::LogProb;
 use crate::variants::evidence::observation::Observation;
 
 pub(crate) mod strand_bias;
+pub(crate) mod read_orientation_bias;
 
 pub(crate) use strand_bias::StrandBias;
+pub(crate) use read_orientation_bias::ReadOrientationBias;
 
 pub(crate) trait Bias {
     fn prob(&self, observation: &Observation) -> LogProb;

--- a/src/variants/model/bias/mod.rs
+++ b/src/variants/model/bias/mod.rs
@@ -1,0 +1,76 @@
+use std::cmp::Ordering;
+
+use bio::stats::probs::LogProb;
+
+use crate::variants::evidence::observation::Observation;
+
+pub(crate) mod strand_bias;
+
+pub(crate) use strand_bias::StrandBias;
+
+pub(crate) trait Bias {
+    fn prob(&self, observation: &Observation) -> LogProb;
+
+    fn prob_any(&self) -> LogProb;
+
+    fn is_artifact(&self) -> bool;
+}
+
+#[derive(Builder, CopyGetters, Getters, Debug, Clone)]
+#[builder(build_fn(name = "build_inner"))]
+pub(crate) struct Biases {
+    #[getset(get = "pub(crate)")]
+    strand_bias: strand_bias::StrandBias,
+    #[getset(get_copy = "pub(crate)")]
+    #[builder(private)]
+    pub(crate) prob_any: LogProb,
+}
+
+impl PartialEq for Biases {
+    fn eq(&self, other: &Self) -> bool {
+        self.strand_bias == other.strand_bias
+    }
+}
+
+impl Eq for Biases {}
+
+impl Ord for Biases {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.strand_bias.cmp(&other.strand_bias)
+    }
+}
+
+impl PartialOrd for Biases {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl BiasesBuilder {
+    pub(crate) fn build(&mut self) -> Result<Biases, String> {
+        let prob_any = self
+            .strand_bias
+            .expect("bug: strand_bias must be set before building")
+            .prob_any();
+
+        self.prob_any(prob_any);
+        self.build_inner()
+    }
+}
+
+impl Biases {
+    pub(crate) fn none() -> Self {
+        BiasesBuilder::default()
+            .strand_bias(StrandBias::None)
+            .build()
+            .unwrap()
+    }
+
+    pub(crate) fn prob(&self, observation: &Observation) -> LogProb {
+        self.strand_bias.prob(observation)
+    }
+
+    pub(crate) fn is_artifact(&self) -> bool {
+        self.strand_bias.is_artifact()
+    }
+}

--- a/src/variants/model/bias/mod.rs
+++ b/src/variants/model/bias/mod.rs
@@ -1,14 +1,16 @@
 use std::cmp::Ordering;
 
 use bio::stats::probs::LogProb;
+use itertools::Itertools;
+use strum::IntoEnumIterator;
 
 use crate::variants::evidence::observation::Observation;
 
-pub(crate) mod strand_bias;
 pub(crate) mod read_orientation_bias;
+pub(crate) mod strand_bias;
 
-pub(crate) use strand_bias::StrandBias;
 pub(crate) use read_orientation_bias::ReadOrientationBias;
+pub(crate) use strand_bias::StrandBias;
 
 pub(crate) trait Bias {
     fn prob(&self, observation: &Observation) -> LogProb;
@@ -22,7 +24,9 @@ pub(crate) trait Bias {
 #[builder(build_fn(name = "build_inner"))]
 pub(crate) struct Biases {
     #[getset(get = "pub(crate)")]
-    strand_bias: strand_bias::StrandBias,
+    strand_bias: StrandBias,
+    #[getset(get = "pub(crate)")]
+    read_orientation_bias: ReadOrientationBias,
     #[getset(get_copy = "pub(crate)")]
     #[builder(private)]
     pub(crate) prob_any: LogProb,
@@ -31,6 +35,7 @@ pub(crate) struct Biases {
 impl PartialEq for Biases {
     fn eq(&self, other: &Self) -> bool {
         self.strand_bias == other.strand_bias
+            && self.read_orientation_bias == other.read_orientation_bias
     }
 }
 
@@ -38,7 +43,9 @@ impl Eq for Biases {}
 
 impl Ord for Biases {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.strand_bias.cmp(&other.strand_bias)
+        self.strand_bias
+            .cmp(&other.strand_bias)
+            .then(self.read_orientation_bias.cmp(&other.read_orientation_bias))
     }
 }
 
@@ -53,7 +60,11 @@ impl BiasesBuilder {
         let prob_any = self
             .strand_bias
             .expect("bug: strand_bias must be set before building")
-            .prob_any();
+            .prob_any()
+            + self
+                .read_orientation_bias
+                .expect("bug: read_orientation_bias must be set before building")
+                .prob_any();
 
         self.prob_any(prob_any);
         self.build_inner()
@@ -61,18 +72,45 @@ impl BiasesBuilder {
 }
 
 impl Biases {
+    pub(crate) fn all_artifact_combinations(
+        consider_read_orientation_bias: bool,
+    ) -> Box<dyn Iterator<Item = Self>> {
+        if consider_read_orientation_bias {
+            Box::new(
+                StrandBias::iter()
+                    .cartesian_product(ReadOrientationBias::iter())
+                    .map(|(strand_bias, read_orientation_bias)| {
+                        BiasesBuilder::default()
+                            .strand_bias(strand_bias)
+                            .read_orientation_bias(read_orientation_bias)
+                            .build()
+                            .unwrap()
+                    }),
+            )
+        } else {
+            Box::new(StrandBias::iter().map(|strand_bias| {
+                BiasesBuilder::default()
+                    .strand_bias(strand_bias)
+                    .read_orientation_bias(ReadOrientationBias::None)
+                    .build()
+                    .unwrap()
+            }))
+        }
+    }
+
     pub(crate) fn none() -> Self {
         BiasesBuilder::default()
             .strand_bias(StrandBias::None)
+            .read_orientation_bias(ReadOrientationBias::None)
             .build()
             .unwrap()
     }
 
     pub(crate) fn prob(&self, observation: &Observation) -> LogProb {
-        self.strand_bias.prob(observation)
+        self.strand_bias.prob(observation) + self.read_orientation_bias.prob(observation)
     }
 
     pub(crate) fn is_artifact(&self) -> bool {
-        self.strand_bias.is_artifact()
+        self.strand_bias.is_artifact() || self.read_orientation_bias.is_artifact()
     }
 }

--- a/src/variants/model/bias/read_orientation_bias.rs
+++ b/src/variants/model/bias/read_orientation_bias.rs
@@ -1,0 +1,42 @@
+use bio::stats::probs::LogProb;
+
+use crate::utils::{PROB_HALF, PROB_ONE_THIRD};
+use crate::variants::evidence::observation::{Observation, ReadOrientation};
+use crate::variants::model::bias::Bias;
+
+#[derive(Copy, Clone, PartialOrd, PartialEq, Eq, Debug, Ord, EnumIter)]
+pub(crate) enum ReadOrientationBias {
+    None,
+    F1R2,
+    F2R1,
+}
+
+impl Default for ReadOrientationBias {
+    fn default() -> Self {
+        ReadOrientationBias::None
+    }
+}
+
+impl Bias for ReadOrientationBias {
+    fn prob(&self, observation: &Observation) -> LogProb {
+        match (self, observation.read_orientation) {
+            (ReadOrientationBias::None, ReadOrientation::F1R2) => *PROB_HALF, // normal
+            (ReadOrientationBias::None, ReadOrientation::F2R1) => *PROB_HALF, // normal
+            (ReadOrientationBias::F1R2, ReadOrientation::F1R2) => LogProb::ln_one(), // bias
+            (ReadOrientationBias::F2R1, ReadOrientation::F2R1) => LogProb::ln_one(), // bias
+            (ReadOrientationBias::F1R2, ReadOrientation::F2R1) => LogProb::ln_zero(), // no bias
+            (ReadOrientationBias::F2R1, ReadOrientation::F1R2) => LogProb::ln_zero(), // no bias
+            (_, ReadOrientation::None) => LogProb::ln_one(), // If we have no information, everything is equally possible.
+            (ReadOrientationBias::None, _) => LogProb::ln_one(), // no bias and "other" observations
+            _ => LogProb::ln_zero(), // other observations make any bias impossible
+        }
+    }
+
+    fn prob_any(&self) -> LogProb {
+        *PROB_HALF
+    }
+
+    fn is_artifact(&self) -> bool {
+        *self != ReadOrientationBias::None
+    }
+}

--- a/src/variants/model/bias/strand_bias.rs
+++ b/src/variants/model/bias/strand_bias.rs
@@ -1,10 +1,10 @@
 use bio::stats::probs::LogProb;
 
-use crate::utils::PROB05;
+use crate::utils::PROB_HALF;
 use crate::variants::evidence::observation::{Observation, Strand};
 use crate::variants::model::bias::Bias;
 
-#[derive(Copy, Clone, PartialOrd, PartialEq, Eq, Debug, Ord)]
+#[derive(Copy, Clone, PartialOrd, PartialEq, Eq, Debug, Ord, EnumIter)]
 pub(crate) enum StrandBias {
     None,
     Forward,
@@ -27,13 +27,13 @@ impl Bias for StrandBias {
             (StrandBias::Forward, Strand::Both) => LogProb::ln_zero(),
             (StrandBias::Reverse, Strand::Both) => LogProb::ln_zero(),
             (StrandBias::None, Strand::Both) => observation.prob_double_overlap,
-            (StrandBias::None, _) => *PROB05 + observation.prob_single_overlap,
+            (StrandBias::None, _) => *PROB_HALF + observation.prob_single_overlap,
             (_, Strand::None) => unreachable!(),
         }
     }
 
     fn prob_any(&self) -> LogProb {
-        *PROB05
+        *PROB_HALF
     }
 
     fn is_artifact(&self) -> bool {

--- a/src/variants/model/bias/strand_bias.rs
+++ b/src/variants/model/bias/strand_bias.rs
@@ -1,0 +1,49 @@
+use bio::stats::probs::LogProb;
+
+use crate::utils::PROB05;
+use crate::variants::evidence::observation::Observation;
+use crate::variants::model::bias::Bias;
+
+#[derive(Copy, Clone, PartialOrd, PartialEq, Eq, Debug, Ord)]
+pub(crate) enum StrandBias {
+    None,
+    Forward,
+    Reverse,
+}
+
+impl Default for StrandBias {
+    fn default() -> Self {
+        StrandBias::None
+    }
+}
+
+impl Bias for StrandBias {
+    fn prob(&self, observation: &Observation) -> LogProb {
+        let obs_strand = (observation.forward_strand, observation.reverse_strand);
+
+        match (self, obs_strand) {
+            (StrandBias::Forward, (true, false)) => LogProb::ln_one(),
+            (StrandBias::Reverse, (true, false)) => LogProb::ln_zero(),
+            (StrandBias::Forward, (false, true)) => LogProb::ln_zero(),
+            (StrandBias::Reverse, (false, true)) => LogProb::ln_one(),
+            (StrandBias::Forward, (true, true)) => LogProb::ln_zero(),
+            (StrandBias::Reverse, (true, true)) => LogProb::ln_zero(),
+            (StrandBias::None, _) => {
+                if observation.forward_strand != observation.reverse_strand {
+                    *PROB05 + observation.prob_single_overlap
+                } else {
+                    observation.prob_double_overlap
+                }
+            }
+            (_, (false, false)) => unreachable!(),
+        }
+    }
+
+    fn prob_any(&self) -> LogProb {
+        *PROB05
+    }
+
+    fn is_artifact(&self) -> bool {
+        *self != StrandBias::None
+    }
+}

--- a/src/variants/model/likelihood.rs
+++ b/src/variants/model/likelihood.rs
@@ -233,17 +233,14 @@ impl Likelihood<SingleSampleCache> for SampleLikelihoodModel {
 mod tests {
     use super::*;
     use crate::variants::model::bias::strand_bias::StrandBias;
-    use crate::variants::model::bias::{Biases, BiasesBuilder};
+    use crate::variants::model::bias::Biases;
     use crate::variants::model::likelihood;
     use crate::variants::model::tests::observation;
     use bio::stats::LogProb;
     use itertools_num::linspace;
 
     fn biases() -> Biases {
-        let mut biases = BiasesBuilder::default()
-            .strand_bias(StrandBias::None)
-            .build()
-            .unwrap();
+        let mut biases = Biases::none();
         // ignore prob_any
         biases.prob_any = LogProb::ln_one();
         biases

--- a/src/variants/model/likelihood.rs
+++ b/src/variants/model/likelihood.rs
@@ -9,7 +9,8 @@ use bio::stats::{bayesian::model::Likelihood, LogProb, Prob};
 
 use crate::utils::NUMERICAL_EPSILON;
 use crate::variants::evidence::observation::Observation;
-use crate::variants::model::{AlleleFreq, StrandBias};
+use crate::variants::model::bias::Biases;
+use crate::variants::model::AlleleFreq;
 use crate::variants::sample::Pileup;
 
 pub(crate) type ContaminatedSampleCache = BTreeMap<ContaminatedSampleEvent, LogProb>;
@@ -18,7 +19,7 @@ pub(crate) type SingleSampleCache = BTreeMap<Event, LogProb>;
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone)]
 pub(crate) struct Event {
     pub(crate) allele_freq: AlleleFreq,
-    pub(crate) strand_bias: StrandBias,
+    pub(crate) biases: Biases,
 }
 
 fn prob_sample_alt(observation: &Observation, allele_freq: LogProb) -> LogProb {
@@ -83,17 +84,17 @@ impl ContaminatedSampleLikelihoodModel {
         &self,
         allele_freq_primary: LogProb,
         allele_freq_secondary: LogProb,
-        strand_bias_primary: StrandBias,
-        strand_bias_secondary: StrandBias,
+        biases_primary: &Biases,
+        biases_secondary: &Biases,
         observation: &Observation,
     ) -> LogProb {
         // Step 1: likelihoods for the mapping case.
         // Case 1: read comes from primary sample and is correctly mapped
         let prob_primary =
-            self.purity + likelihood_mapping(allele_freq_primary, strand_bias_primary, observation);
+            self.purity + likelihood_mapping(allele_freq_primary, biases_primary, observation);
         // Case 2: read comes from secondary sample and is correctly mapped
         let prob_secondary = self.impurity
-            + likelihood_mapping(allele_freq_secondary, strand_bias_secondary, observation);
+            + likelihood_mapping(allele_freq_secondary, biases_secondary, observation);
 
         // Step 4: total probability
         // Important note: we need to multiply a probability for a hypothetical missed allele
@@ -104,7 +105,7 @@ impl ContaminatedSampleLikelihoodModel {
             .ln_add_exp(
                 observation.prob_mismapping
                     + observation.prob_missed_allele
-                    + observation.prob_any_strand,
+                    + biases_primary.prob_any(),
             );
         assert!(!total.is_nan());
         total
@@ -132,8 +133,8 @@ impl Likelihood<ContaminatedSampleCache> for ContaminatedSampleLikelihoodModel {
                 let lh = self.likelihood_observation(
                     ln_af_primary,
                     ln_af_secondary,
-                    events.primary.strand_bias,
-                    events.secondary.strand_bias,
+                    &events.primary.biases,
+                    &events.secondary.biases,
                     obs,
                 );
                 prob + lh
@@ -161,11 +162,11 @@ impl SampleLikelihoodModel {
     fn likelihood_observation(
         &self,
         allele_freq: LogProb,
-        strand_bias: StrandBias,
+        biases: &Biases,
         observation: &Observation,
     ) -> LogProb {
         // Step 1: likelihood for the mapping case.
-        let prob = likelihood_mapping(allele_freq, strand_bias, observation);
+        let prob = likelihood_mapping(allele_freq, biases, observation);
 
         // Step 2: total probability
         // Important note: we need to multiply a probability for a hypothetical missed allele
@@ -173,9 +174,7 @@ impl SampleLikelihoodModel {
         // differences in the likelihood for alt and ref allele with low probabilities and very
         // low allele frequencies, such that we loose sensitivity for those.
         let total = (observation.prob_mapping + prob).ln_add_exp(
-            observation.prob_mismapping
-                + observation.prob_missed_allele
-                + observation.prob_any_strand,
+            observation.prob_mismapping + observation.prob_missed_allele + biases.prob_any(),
         );
         assert!(!total.is_nan());
         total
@@ -184,40 +183,20 @@ impl SampleLikelihoodModel {
 
 /// Calculate likelihood of allele freq given observation in a single sample assuming that the
 /// underlying fragment/read is mapped correctly.
-fn likelihood_mapping(
-    allele_freq: LogProb,
-    strand_bias: StrandBias,
-    observation: &Observation,
-) -> LogProb {
+fn likelihood_mapping(allele_freq: LogProb, biases: &Biases, observation: &Observation) -> LogProb {
     // Step 1: calculate probability to sample from alt allele
     let prob_sample_alt = prob_sample_alt(observation, allele_freq);
     let prob_sample_ref = prob_sample_alt.ln_one_minus_exp();
 
-    let obs_strand = (observation.forward_strand, observation.reverse_strand);
-
-    let prob_strand = match (strand_bias, obs_strand) {
-        (StrandBias::Forward, (true, false)) => LogProb::ln_one(),
-        (StrandBias::Reverse, (true, false)) => LogProb::ln_zero(),
-        (StrandBias::Forward, (false, true)) => LogProb::ln_zero(),
-        (StrandBias::Reverse, (false, true)) => LogProb::ln_one(),
-        (StrandBias::Forward, (true, true)) => LogProb::ln_zero(),
-        (StrandBias::Reverse, (true, true)) => LogProb::ln_zero(),
-        (StrandBias::None, _) => {
-            if observation.forward_strand != observation.reverse_strand {
-                LogProb::from(Prob(0.5)) + observation.prob_single_overlap
-            } else {
-                observation.prob_double_overlap
-            }
-        }
-        (_, (false, false)) => unreachable!(),
-    };
+    let prob_bias = biases.prob(observation);
+    let prob_any_bias = biases.prob_any();
 
     // Step 2: read comes from case sample and is correctly mapped
     let prob = LogProb::ln_sum_exp(&[
         // alt allele
-        prob_sample_alt + prob_strand + observation.prob_alt,
+        prob_sample_alt + prob_bias + observation.prob_alt,
         // ref allele (we don't care about the strand)
-        prob_sample_ref + observation.prob_ref + observation.prob_any_strand,
+        prob_sample_ref + observation.prob_ref + prob_any_bias,
     ]);
     assert!(!prob.is_nan());
 
@@ -237,7 +216,7 @@ impl Likelihood<SingleSampleCache> for SampleLikelihoodModel {
 
             // calculate product of per-read likelihoods in log space
             let likelihood = pileup.iter().fold(LogProb::ln_one(), |prob, obs| {
-                let lh = self.likelihood_observation(ln_af, event.strand_bias, obs);
+                let lh = self.likelihood_observation(ln_af, &event.biases, obs);
                 prob + lh
             });
 
@@ -253,16 +232,27 @@ impl Likelihood<SingleSampleCache> for SampleLikelihoodModel {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::variants::model::bias::strand_bias::StrandBias;
+    use crate::variants::model::bias::{Biases, BiasesBuilder};
     use crate::variants::model::likelihood;
     use crate::variants::model::tests::observation;
-    use crate::variants::model::StrandBias;
     use bio::stats::LogProb;
     use itertools_num::linspace;
+
+    fn biases() -> Biases {
+        let mut biases = BiasesBuilder::default()
+            .strand_bias(StrandBias::None)
+            .build()
+            .unwrap();
+        // ignore prob_any
+        biases.prob_any = LogProb::ln_one();
+        biases
+    }
 
     fn event(allele_freq: f64) -> Event {
         Event {
             allele_freq: AlleleFreq(allele_freq),
-            strand_bias: StrandBias::None,
+            biases: biases(),
         }
     }
 
@@ -272,11 +262,8 @@ mod tests {
 
         let model = SampleLikelihoodModel::new();
 
-        let lh = model.likelihood_observation(
-            LogProb(AlleleFreq(0.0).ln()),
-            StrandBias::None,
-            &observation,
-        );
+        let lh =
+            model.likelihood_observation(LogProb(AlleleFreq(0.0).ln()), &biases(), &observation);
         assert_relative_eq!(*lh, *LogProb::ln_one());
     }
 
@@ -288,8 +275,8 @@ mod tests {
         let lh = model.likelihood_observation(
             LogProb(AlleleFreq(0.0).ln()),
             LogProb(AlleleFreq(0.0).ln()),
-            StrandBias::None,
-            StrandBias::None,
+            &biases(),
+            &biases(),
             &observation,
         );
         assert_relative_eq!(*lh, *LogProb::ln_one());
@@ -345,8 +332,8 @@ mod tests {
         let lh = model.likelihood_observation(
             LogProb(AlleleFreq(1.0).ln()),
             LogProb(AlleleFreq(0.0).ln()),
-            StrandBias::None,
-            StrandBias::None,
+            &biases(),
+            &biases(),
             &observation,
         );
         assert_relative_eq!(*lh, *LogProb::ln_one());
@@ -354,8 +341,8 @@ mod tests {
         let lh = model.likelihood_observation(
             LogProb(AlleleFreq(0.0).ln()),
             LogProb(AlleleFreq(0.0).ln()),
-            StrandBias::None,
-            StrandBias::None,
+            &biases(),
+            &biases(),
             &observation,
         );
         assert_relative_eq!(*lh, *LogProb::ln_zero());
@@ -363,8 +350,8 @@ mod tests {
         let lh = model.likelihood_observation(
             LogProb(AlleleFreq(0.5).ln()),
             LogProb(AlleleFreq(0.0).ln()),
-            StrandBias::None,
-            StrandBias::None,
+            &biases(),
+            &biases(),
             &observation,
         );
         assert_relative_eq!(*lh, 0.5f64.ln());
@@ -372,8 +359,8 @@ mod tests {
         let lh = model.likelihood_observation(
             LogProb(AlleleFreq(0.5).ln()),
             LogProb(AlleleFreq(0.5).ln()),
-            StrandBias::None,
-            StrandBias::None,
+            &biases(),
+            &biases(),
             &observation,
         );
         assert_relative_eq!(*lh, 0.5f64.ln());
@@ -381,8 +368,8 @@ mod tests {
         let lh = model.likelihood_observation(
             LogProb(AlleleFreq(0.1).ln()),
             LogProb(AlleleFreq(0.0).ln()),
-            StrandBias::None,
-            StrandBias::None,
+            &biases(),
+            &biases(),
             &observation,
         );
         assert_relative_eq!(*lh, 0.1f64.ln());
@@ -393,8 +380,8 @@ mod tests {
         let lh = model.likelihood_observation(
             LogProb(AlleleFreq(0.0).ln()),
             LogProb(AlleleFreq(1.0).ln()),
-            StrandBias::None,
-            StrandBias::None,
+            &biases(),
+            &biases(),
             &observation,
         );
         assert_relative_eq!(*lh, 0.5f64.ln(), epsilon = 0.0000000001);
@@ -413,32 +400,20 @@ mod tests {
             LogProb::ln_zero(),
         );
 
-        let lh = model.likelihood_observation(
-            LogProb(AlleleFreq(1.0).ln()),
-            StrandBias::None,
-            &observation,
-        );
+        let lh =
+            model.likelihood_observation(LogProb(AlleleFreq(1.0).ln()), &biases(), &observation);
         assert_relative_eq!(*lh, *LogProb::ln_one());
 
-        let lh = model.likelihood_observation(
-            LogProb(AlleleFreq(0.0).ln()),
-            StrandBias::None,
-            &observation,
-        );
+        let lh =
+            model.likelihood_observation(LogProb(AlleleFreq(0.0).ln()), &biases(), &observation);
         assert_relative_eq!(*lh, *LogProb::ln_zero());
 
-        let lh = model.likelihood_observation(
-            LogProb(AlleleFreq(0.5).ln()),
-            StrandBias::None,
-            &observation,
-        );
+        let lh =
+            model.likelihood_observation(LogProb(AlleleFreq(0.5).ln()), &biases(), &observation);
         assert_relative_eq!(*lh, 0.5f64.ln());
 
-        let lh = model.likelihood_observation(
-            LogProb(AlleleFreq(0.1).ln()),
-            StrandBias::None,
-            &observation,
-        );
+        let lh =
+            model.likelihood_observation(LogProb(AlleleFreq(0.1).ln()), &biases(), &observation);
         assert_relative_eq!(*lh, 0.1f64.ln());
     }
 

--- a/src/variants/model/mod.rs
+++ b/src/variants/model/mod.rs
@@ -244,7 +244,7 @@ impl Variant {
 
 #[cfg(test)]
 mod tests {
-    use crate::variants::evidence::observation::{Observation, ObservationBuilder};
+    use crate::variants::evidence::observation::{Observation, ObservationBuilder, Strand};
 
     use bio::stats::LogProb;
 
@@ -260,9 +260,7 @@ mod tests {
             .prob_missed_allele(prob_ref.ln_add_exp(prob_alt) - LogProb(2.0_f64.ln()))
             .prob_sample_alt(LogProb::ln_one())
             .prob_overlap(LogProb::ln_one())
-            .prob_any_strand(LogProb::ln_one())
-            .forward_strand(true)
-            .reverse_strand(true)
+            .strand(Strand::Both)
             .build()
             .unwrap()
     }

--- a/src/variants/model/mod.rs
+++ b/src/variants/model/mod.rs
@@ -12,7 +12,9 @@ use ordered_float::NotNan;
 use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 
 use crate::grammar;
+use crate::variants::model::bias::Biases;
 
+pub(crate) mod bias;
 pub(crate) mod likelihood;
 pub(crate) mod modes;
 
@@ -26,39 +28,16 @@ pub(crate) struct Contamination {
 pub(crate) struct Event {
     pub(crate) name: String,
     pub(crate) vafs: grammar::VAFTree,
-    pub(crate) strand_bias: StrandBias,
+    pub(crate) biases: Biases,
 }
 
 impl Event {
     pub(crate) fn is_artifact(&self) -> bool {
-        self.strand_bias != StrandBias::None
+        self.biases.is_artifact()
     }
 }
 
 pub(crate) type AlleleFreq = NotNan<f64>;
-
-#[derive(Copy, Clone, PartialOrd, PartialEq, Eq, Debug, Ord)]
-pub(crate) enum StrandBias {
-    None,
-    Forward,
-    Reverse,
-}
-
-impl Default for StrandBias {
-    fn default() -> Self {
-        StrandBias::None
-    }
-}
-
-impl StrandBias {
-    pub(crate) fn is_some(&self) -> bool {
-        if let StrandBias::None = self {
-            false
-        } else {
-            true
-        }
-    }
-}
 
 #[allow(non_snake_case)]
 pub(crate) fn AlleleFreq(af: f64) -> AlleleFreq {

--- a/src/variants/model/mod.rs
+++ b/src/variants/model/mod.rs
@@ -244,7 +244,9 @@ impl Variant {
 
 #[cfg(test)]
 mod tests {
-    use crate::variants::evidence::observation::{Observation, ObservationBuilder, Strand};
+    use crate::variants::evidence::observation::{
+        Observation, ObservationBuilder, ReadOrientation, Strand,
+    };
 
     use bio::stats::LogProb;
 
@@ -260,6 +262,7 @@ mod tests {
             .prob_missed_allele(prob_ref.ln_add_exp(prob_alt) - LogProb(2.0_f64.ln()))
             .prob_sample_alt(LogProb::ln_one())
             .prob_overlap(LogProb::ln_one())
+            .read_orientation(ReadOrientation::None)
             .strand(Strand::Both)
             .build()
             .unwrap()

--- a/src/variants/model/modes/generic.rs
+++ b/src/variants/model/modes/generic.rs
@@ -9,7 +9,7 @@ use vec_map::VecMap;
 use crate::grammar;
 use crate::variants::model;
 use crate::variants::model::likelihood;
-use crate::variants::model::{AlleleFreq, Contamination, StrandBias};
+use crate::variants::model::{bias::Biases, AlleleFreq, Contamination};
 use crate::variants::sample::Pileup;
 
 #[derive(new, Clone, Debug)]
@@ -126,7 +126,7 @@ impl GenericPosterior {
         base_events: &mut VecMap<likelihood::Event>,
         sample_grid_points: &[usize],
         data: &<Self as Posterior>::Data,
-        strand_bias: StrandBias,
+        biases: &Biases,
         joint_prob: &mut F,
     ) -> LogProb {
         let mut subdensity = |base_events: &mut VecMap<likelihood::Event>| {
@@ -143,7 +143,7 @@ impl GenericPosterior {
                                 &mut base_events.clone(),
                                 sample_grid_points,
                                 data,
-                                strand_bias,
+                                biases,
                                 joint_prob,
                             )
                         })
@@ -155,7 +155,7 @@ impl GenericPosterior {
                     base_events,
                     sample_grid_points,
                     data,
-                    strand_bias,
+                    biases,
                     joint_prob,
                 )
             }
@@ -168,7 +168,7 @@ impl GenericPosterior {
                         *sample,
                         likelihood::Event {
                             allele_freq,
-                            strand_bias,
+                            biases: biases.clone(),
                         },
                     );
                 };
@@ -253,7 +253,7 @@ impl Posterior for GenericPosterior {
                         &mut base_events,
                         &grid_points,
                         data,
-                        event.strand_bias,
+                        &event.biases,
                         joint_prob,
                     )
                 })


### PR DESCRIPTION
This enables us to detect Guanin oxidation errors.