### PR TITLE
remove possibility of using alignment_properties.insert_size when it is None

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -505,10 +505,11 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
 
                     // If we omit the insert size information for calculating the evidence, we can savely allow hardclips here.
                     let allow_hardclips = omit_insert_size;
-                    let alignment_properties = est_or_load_alignment_properites(
+                    let alignment_properties = est_or_load_alignment_properties(
                         &alignment_properties,
                         &bam,
-                        allow_hardclips,
+                        omit_insert_size,
+                        allow_hardclips
                     )?;
 
                     let gap_params = GapParams {
@@ -838,16 +839,17 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn est_or_load_alignment_properites(
+pub(crate) fn est_or_load_alignment_properties(
     alignment_properties_file: &Option<impl AsRef<Path>>,
     bam_file: impl AsRef<Path>,
     omit_insert_size: bool,
+    allow_hardclips: bool,
 ) -> Result<AlignmentProperties> {
     if let Some(alignment_properties_file) = alignment_properties_file {
         Ok(serde_json::from_reader(File::open(
             alignment_properties_file,
         )?)?)
     } else {
-        estimate_alignment_properties(bam_file, omit_insert_size)
+        estimate_alignment_properties(bam_file, omit_insert_size, allow_hardclips)
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -509,7 +509,7 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
                         &alignment_properties,
                         &bam,
                         omit_insert_size,
-                        allow_hardclips
+                        allow_hardclips,
                     )?;
 
                     let gap_params = GapParams {

--- a/src/estimation/alignment_properties.rs
+++ b/src/estimation/alignment_properties.rs
@@ -15,7 +15,7 @@ use statrs::statistics::{OrderStatistics, Statistics};
 
 #[derive(Clone, Debug, Copy, Deserialize, Serialize)]
 pub(crate) struct AlignmentProperties {
-    insert_size: Option<InsertSize>,
+    pub(crate) insert_size: Option<InsertSize>,
     pub(crate) max_del_cigar_len: u32,
     pub(crate) max_ins_cigar_len: u32,
     pub(crate) frac_max_softclip: f64,
@@ -63,7 +63,7 @@ impl AlignmentProperties {
 
     /// Estimate `AlignmentProperties` from first 10000 fragments of bam file.
     /// Only reads that are mapped, not duplicates and where quality checks passed are taken.
-    pub(crate) fn estimate<R: bam::Read>(bam: &mut R, allow_hardclips: bool) -> Result<Self> {
+    pub(crate) fn estimate<R: bam::Read>(bam: &mut R, omit_insert_size: bool, allow_hardclips: bool) -> Result<Self> {
         let mut properties = AlignmentProperties {
             insert_size: None,
             max_del_cigar_len: 0,
@@ -112,6 +112,11 @@ impl AlignmentProperties {
             let (is_regular, has_soft_clip) =
                 properties.update_max_cigar_ops_len(&record, allow_hardclips);
 
+            // If we are not using the insert size, we do not need to estimate it
+            if omit_insert_size {
+                i += 1;
+                continue;
+            }
             // Records to skip after updating max_cigar_ops_len, BUT without incrementing the
             // counter (to keep looking for 10000 useful records for the estimation)
             if !record.is_paired()
@@ -183,13 +188,6 @@ impl AlignmentProperties {
         }
     }
 
-    pub(crate) fn insert_size(&self) -> &InsertSize {
-        match &self.insert_size {
-            Some(insert_size)  => insert_size,
-            None => panic!("This is a bug.\n
-                            AlignmentProperties has insert_size set to `None`, but you are trying to use it without checking for None.")
-        }
-    }
 }
 
 /// Expected insert size in terms of mean and standard deviation.
@@ -208,11 +206,15 @@ mod tests {
     fn test_estimate() {
         let mut bam = bam::Reader::from_path("tests/resources/tumor-first30000.bam").unwrap();
 
-        let props = AlignmentProperties::estimate(&mut bam, false).unwrap();
+        let props = AlignmentProperties::estimate(&mut bam, false, false).unwrap();
         println!("{:?}", props);
 
-        assert_relative_eq!(props.insert_size().mean, 311.9736111111111);
-        assert_relative_eq!(props.insert_size().sd, 11.9001225301502);
+        if let Some(isize) = props.insert_size {
+            assert_relative_eq!(isize.mean, 311.9736111111111);
+            assert_relative_eq!(isize.sd, 11.9001225301502);
+        } else {
+            panic!("test_estimate(): props.insert_size was None. Something is wrong, here.");
+        }
         assert_eq!(props.max_del_cigar_len, 30);
         assert_eq!(props.max_ins_cigar_len, 12);
         assert_eq!(props.frac_max_softclip, 0.63);
@@ -224,7 +226,7 @@ mod tests {
             bam::Reader::from_path("tests/resources/tumor-first30000.reads_with_soft_clips.bam")
                 .unwrap();
 
-        let props = AlignmentProperties::estimate(&mut bam, false).unwrap();
+        let props = AlignmentProperties::estimate(&mut bam, false, false).unwrap();
         println!("{:?}", props);
 
         assert!(props.insert_size.is_none());
@@ -241,7 +243,7 @@ mod tests {
         )
         .unwrap();
 
-        let props = AlignmentProperties::estimate(&mut bam, false).unwrap();
+        let props = AlignmentProperties::estimate(&mut bam, false, false).unwrap();
         println!("{:?}", props);
 
         assert!(props.insert_size.is_none());

--- a/src/estimation/alignment_properties.rs
+++ b/src/estimation/alignment_properties.rs
@@ -63,7 +63,11 @@ impl AlignmentProperties {
 
     /// Estimate `AlignmentProperties` from first 10000 fragments of bam file.
     /// Only reads that are mapped, not duplicates and where quality checks passed are taken.
-    pub(crate) fn estimate<R: bam::Read>(bam: &mut R, omit_insert_size: bool, allow_hardclips: bool) -> Result<Self> {
+    pub(crate) fn estimate<R: bam::Read>(
+        bam: &mut R,
+        omit_insert_size: bool,
+        allow_hardclips: bool,
+    ) -> Result<Self> {
         let mut properties = AlignmentProperties {
             insert_size: None,
             max_del_cigar_len: 0,
@@ -187,7 +191,6 @@ impl AlignmentProperties {
             Ok(properties)
         }
     }
-
 }
 
 /// Expected insert size in terms of mean and standard deviation.

--- a/src/testcase.rs
+++ b/src/testcase.rs
@@ -292,7 +292,7 @@ impl Testcase {
         // second pass, write samples
         let mut samples = HashMap::new();
         for (name, path) in &self.bams {
-            let properties = sample::estimate_alignment_properties(path, false)?;
+            let properties = sample::estimate_alignment_properties(path, false, false)?;
             let mut bam_reader = bam::IndexedReader::from_path(path)?;
             let filename = Path::new(name).with_extension("bam");
             let mut bam_writer = bam::Writer::from_path(

--- a/src/variants/sample.rs
+++ b/src/variants/sample.rs
@@ -167,7 +167,7 @@ pub(crate) fn estimate_alignment_properties<P: AsRef<Path>>(
     Ok(alignment_properties::AlignmentProperties::estimate(
         &mut bam,
         omit_insert_size,
-        allow_hardclips
+        allow_hardclips,
     )?)
 }
 
@@ -198,12 +198,8 @@ impl SampleBuilder {
     ) -> Self {
         let single_read_window = alignment_properties.max_read_len as u64;
         let read_pair_window = match alignment_properties.insert_size {
-            Some(isize) => {
-                 (isize.mean + isize.sd * 6.0) as u64
-            },
-            None => {
-                single_read_window
-            }
+            Some(isize) => (isize.mean + isize.sd * 6.0) as u64,
+            None => single_read_window,
         };
         self.alignment_properties(alignment_properties)
             .record_buffer(RecordBuffer::new(

--- a/src/variants/sample.rs
+++ b/src/variants/sample.rs
@@ -161,11 +161,13 @@ impl SubsampleCandidates {
 pub(crate) fn estimate_alignment_properties<P: AsRef<Path>>(
     path: P,
     omit_insert_size: bool,
+    allow_hardclips: bool,
 ) -> Result<alignment_properties::AlignmentProperties> {
     let mut bam = bam::Reader::from_path(path)?;
     Ok(alignment_properties::AlignmentProperties::estimate(
         &mut bam,
         omit_insert_size,
+        allow_hardclips
     )?)
 }
 
@@ -194,9 +196,15 @@ impl SampleBuilder {
         bam: bam::IndexedReader,
         alignment_properties: alignment_properties::AlignmentProperties,
     ) -> Self {
-        let read_pair_window = (alignment_properties.insert_size().mean
-            + alignment_properties.insert_size().sd * 6.0) as u64;
         let single_read_window = alignment_properties.max_read_len as u64;
+        let read_pair_window = match alignment_properties.insert_size {
+            Some(isize) => {
+                 (isize.mean + isize.sd * 6.0) as u64
+            },
+            None => {
+                single_read_window
+            }
+        };
         self.alignment_properties(alignment_properties)
             .record_buffer(RecordBuffer::new(
                 bam::RecordBuffer::new(bam, true),

--- a/src/variants/sampling_bias/fragments.rs
+++ b/src/variants/sampling_bias/fragments.rs
@@ -36,14 +36,10 @@ pub(crate) trait FragmentSamplingBias: Variant + SamplingBias {
         alignment_properties: &AlignmentProperties,
     ) -> LogProb {
         match alignment_properties.insert_size {
-            Some(isize) => {
-                isize_pmf(
-                    insert_size as f64,
-                    isize.mean + shift,
-                    isize.sd,
-                )
-            },
-            None => panic!("Bug: Tried to get an isize_pmf(), but alignment_properties.insert_size was None.")
+            Some(isize) => isize_pmf(insert_size as f64, isize.mean + shift, isize.sd),
+            None => panic!(
+                "Bug: Tried to get an isize_pmf(), but alignment_properties.insert_size was None."
+            ),
         }
     }
 

--- a/src/variants/sampling_bias/fragments.rs
+++ b/src/variants/sampling_bias/fragments.rs
@@ -18,9 +18,14 @@ pub(crate) trait FragmentSamplingBias: Variant + SamplingBias {
     /// Get range of insert sizes with probability above zero.
     /// We use 6 SDs around the mean.
     fn isize_pmf_range(&self, alignment_properties: &AlignmentProperties) -> Range<u64> {
-        let m = alignment_properties.insert_size().mean.round() as u64;
-        let s = alignment_properties.insert_size().sd.ceil() as u64 * 6;
-        m.saturating_sub(s)..m + s
+        match alignment_properties.insert_size {
+            Some(isize) => {
+                let m = isize.mean.round() as u64;
+                let s = isize.sd.ceil() as u64 * 6;
+                m.saturating_sub(s)..m + s
+            },
+            None => panic!("Bug: Tried to create an isize_pmf_range(), but alignment_properties.insert_size was None.")
+        }
     }
 
     /// Get probability of given insert size from distribution shifted by the given value.
@@ -30,11 +35,16 @@ pub(crate) trait FragmentSamplingBias: Variant + SamplingBias {
         shift: f64,
         alignment_properties: &AlignmentProperties,
     ) -> LogProb {
-        isize_pmf(
-            insert_size as f64,
-            alignment_properties.insert_size().mean + shift,
-            alignment_properties.insert_size().sd,
-        )
+        match alignment_properties.insert_size {
+            Some(isize) => {
+                isize_pmf(
+                    insert_size as f64,
+                    isize.mean + shift,
+                    isize.sd,
+                )
+            },
+            None => panic!("Bug: Tried to get an isize_pmf(), but alignment_properties.insert_size was None.")
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -142,8 +152,13 @@ pub(crate) trait FragmentSamplingBias: Variant + SamplingBias {
         shift: f64,
         alignment_properties: &AlignmentProperties,
     ) -> bool {
-        let m = alignment_properties.insert_size().mean + shift;
-        (insert_size as f64 - m).abs() <= alignment_properties.insert_size().sd
+        match alignment_properties.insert_size {
+            Some(isize) => {
+                let m = isize.mean + shift;
+                (insert_size as f64 - m).abs() <= isize.sd
+            },
+            None => panic!("Bug: Tried to check whether is_within_sd(), but alignment_properties.insert_size was None.")
+        }
     }
 }
 


### PR DESCRIPTION
When running varlociraptor on some single end read data, I got this panic!() that I had put there a while ago:
```
AlignmentProperties has insert_size set to `None`, but you are trying to use it without checking for None.This is a bug.
```

The backtrace indicates, that the problem is in `varlociraptor::variants::sample::SampleBuilder::alignments()`:
```
   0: backtrace::backtrace::libunwind::trace
             at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.46/src/backtrace/libunwind.rs:86
   1: backtrace::backtrace::trace_unsynchronized
             at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.46/src/backtrace/mod.rs:66
   2: std::sys_common::backtrace::_print_fmt
             at src/libstd/sys_common/backtrace.rs:78
   3: <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt
             at src/libstd/sys_common/backtrace.rs:59
   4: core::fmt::write
             at src/libcore/fmt/mod.rs:1076
   5: std::io::Write::write_fmt
             at src/libstd/io/mod.rs:1537
   6: std::sys_common::backtrace::_print
             at src/libstd/sys_common/backtrace.rs:62
   7: std::sys_common::backtrace::print
             at src/libstd/sys_common/backtrace.rs:49
   8: std::panicking::default_hook::{{closure}}
             at src/libstd/panicking.rs:198
   9: std::panicking::default_hook
             at src/libstd/panicking.rs:217
  10: std::panicking::rust_panic_with_hook
             at src/libstd/panicking.rs:526
  11: std::panicking::begin_panic
  12: varlociraptor::variants::sample::SampleBuilder::alignments
  13: crossbeam_utils::thread::ScopedThreadBuilder::spawn::{{closure}}
```

But I just removed the `insert_size()` function and replaced it with a public instance of `insert_size` in `AlignmentProperties` and then try to handle every case where an `insert_size` is used. Please feel free to correct any of the behaviour I put there, be it the handling I implemented or the `panic!()`s that I put wherever I had no clue what else to do with a `None` right there.

And one point I still do not get is what the `--omit_insert_size` flag actually does. I don't think that it actually prevents the usage of the `insert_size` information...?!