### PR TITLE
Use precomputed base miscall and call likelihoods.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,3 +75,6 @@ serde_json = "1"
 default = []
 gslv2 = ["GSL/v2"]
 use-intrinsics = ["half/use-intrinsics"]
+
+[profile.release]
+debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,5 +76,5 @@ default = []
 gslv2 = ["GSL/v2"]
 use-intrinsics = ["half/use-intrinsics"]
 
-[profile.release]
-debug = true
+#[profile.release]
+#debug = true

--- a/src/variants/evidence/bases.rs
+++ b/src/variants/evidence/bases.rs
@@ -11,17 +11,28 @@ lazy_static! {
 
 /// Calculate probability of read_base given ref_base.
 pub(crate) fn prob_read_base(read_base: u8, ref_base: u8, base_qual: u8) -> LogProb {
-    let prob_miscall = prob_read_base_miscall(base_qual);
-
     if read_base.to_ascii_uppercase() == ref_base.to_ascii_uppercase() {
-        prob_miscall.ln_one_minus_exp()
+        BASEQUAL_TO_PROB_CALL[base_qual as usize]
     } else {
+        let prob_miscall = prob_read_base_miscall(base_qual);
         // TODO replace the second term with technology specific confusion matrix
         prob_miscall + *PROB_CONFUSION
     }
 }
 
-/// unpack miscall probability of read_base.
+/// Unpack miscall probability of read_base.
 pub(crate) fn prob_read_base_miscall(base_qual: u8) -> LogProb {
+    BASEQUAL_TO_PROB_MISCALL[base_qual as usize]
+}
+
+/// unpack miscall probability of read_base.
+fn _prob_read_base_miscall(base_qual: u8) -> LogProb {
     LogProb::from(PHREDProb::from((base_qual) as f64))
+}
+
+lazy_static! {
+    pub(crate) static ref BASEQUAL_TO_PROB_MISCALL: [LogProb; 256] =
+        (0u8..256u8).map(|qual| _prob_read_base_miscall(qual));
+    pub(crate) static ref BASEQUAL_TO_PROB_CALL: [LogProb; 256] =
+        (0u8..256u8).map(|qual| _prob_read_base_miscall(qual).ln_one_minus_exp());
 }

--- a/src/variants/evidence/bases.rs
+++ b/src/variants/evidence/bases.rs
@@ -31,8 +31,18 @@ fn _prob_read_base_miscall(base_qual: u8) -> LogProb {
 }
 
 lazy_static! {
-    pub(crate) static ref BASEQUAL_TO_PROB_MISCALL: [LogProb; 256] =
-        (0u8..256u8).map(|qual| _prob_read_base_miscall(qual));
-    pub(crate) static ref BASEQUAL_TO_PROB_CALL: [LogProb; 256] =
-        (0u8..256u8).map(|qual| _prob_read_base_miscall(qual).ln_one_minus_exp());
+    pub(crate) static ref BASEQUAL_TO_PROB_MISCALL: [LogProb; 256] = {
+        let mut probs = [LogProb::ln_zero(); 256];
+        for (qual, prob) in (0u8..=255u8).map(|qual| (qual, _prob_read_base_miscall(qual))) {
+            probs[qual as usize] = prob;
+        }
+        probs
+    };
+    pub(crate) static ref BASEQUAL_TO_PROB_CALL: [LogProb; 256] = {
+        let mut probs = [LogProb::ln_zero(); 256];
+        for (qual, prob) in BASEQUAL_TO_PROB_MISCALL.iter().enumerate() {
+            probs[qual] = *prob;
+        }
+        probs
+    };
 }

--- a/src/variants/evidence/bases.rs
+++ b/src/variants/evidence/bases.rs
@@ -41,7 +41,7 @@ lazy_static! {
     pub(crate) static ref BASEQUAL_TO_PROB_CALL: [LogProb; 256] = {
         let mut probs = [LogProb::ln_zero(); 256];
         for (qual, prob) in BASEQUAL_TO_PROB_MISCALL.iter().enumerate() {
-            probs[qual] = *prob;
+            probs[qual] = prob.ln_one_minus_exp();
         }
         probs
     };

--- a/src/variants/evidence/realignment/pairhmm.rs
+++ b/src/variants/evidence/realignment/pairhmm.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use bio::stats::pairhmm;
 use bio::stats::{LogProb, PHREDProb, Prob};
 
+use crate::variants::evidence::bases::prob_read_base_miscall;
 use crate::variants::evidence::realignment::edit_distance::EditDistanceHit;
 
 /// Width of band around alignment with optimal edit distance.
@@ -19,11 +20,6 @@ pub(crate) const EDIT_BAND: usize = 2;
 
 lazy_static! {
     static ref PROB_CONFUSION: LogProb = LogProb::from(Prob(0.3333));
-}
-
-/// unpack miscall probability of read_base.
-pub(crate) fn prob_read_base_miscall(base_qual: u8) -> LogProb {
-    LogProb::from(PHREDProb::from((base_qual) as f64))
 }
 
 pub(crate) trait RefBaseEmission {


### PR DESCRIPTION
This is slightly faster than calculating them on the fly.