### PR TITLE
Multi-sample TMB plotting

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -284,7 +284,7 @@ pub enum EstimateKind {
         #[structopt(
             long = "tumor-sample",
             default_value = "tumor",
-            help = "Names of the tumor samples in the given VCF/BCF."
+            help = "Name(s) of the tumor sample(s) in the given VCF/BCF. Multiple samples can be given when using the multibar plot mode."
         )]
         tumor_sample: Vec<String>,
         #[structopt(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -284,9 +284,9 @@ pub enum EstimateKind {
         #[structopt(
             long = "tumor-sample",
             default_value = "tumor",
-            help = "Name of the tumor sample in the given VCF/BCF."
+            help = "Names of the tumor samples in the given VCF/BCF."
         )]
-        tumor_sample: String,
+        tumor_sample: Vec<String>,
         #[structopt(
             long = "coding-genome-size",
             default_value = "3e7",
@@ -296,9 +296,15 @@ pub enum EstimateKind {
         #[structopt(
             long = "plot-mode",
             possible_values = &estimation::tumor_mutational_burden::PlotMode::iter().map(|v| v.into()).collect_vec(),
-            help = "How to plot (as stratified curve or as histogram)."
+            help = "How to plot (as stratified curve, histogram or multi-sample barplot)."
         )]
         mode: estimation::tumor_mutational_burden::PlotMode,
+        #[structopt(
+            long = "vaf-cutoff",
+            default_value = "0.2",
+            help = "Minimal variant allelic fraction to consider for mutli-sample barplot"
+        )]
+        cutoff: f64,
     },
 }
 
@@ -917,11 +923,13 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
                 tumor_sample,
                 coding_genome_size,
                 mode,
-            } => estimation::tumor_mutational_burden::estimate(
+                cutoff,
+            } => estimation::tumor_mutational_burden::collect_estimates(
                 &somatic_tumor_events,
                 &tumor_sample,
                 coding_genome_size as u64,
                 mode,
+                cutoff as f64,
             )?,
         },
     }

--- a/src/estimation/tumor_mutational_burden.rs
+++ b/src/estimation/tumor_mutational_burden.rs
@@ -171,7 +171,6 @@ pub(crate) fn collect_estimates(
         }
     }
     if tmb.is_empty() {
-        println!("Empty");
         return Err(errors::Error::NoRecordsFound.into());
     }
 

--- a/src/estimation/tumor_mutational_burden.rs
+++ b/src/estimation/tumor_mutational_burden.rs
@@ -63,7 +63,7 @@ struct TMBMultiBar {
     vaf: f64,
     tmb: f64,
     vartype: Signature,
-    sample: String
+    sample: String,
 }
 
 struct RecordSig {
@@ -88,7 +88,7 @@ struct RecordSig {
 pub enum PlotMode {
     Hist,
     Curve,
-    Multibar
+    Multibar,
 }
 
 pub(crate) fn collect_estimates(
@@ -165,7 +165,7 @@ pub(crate) fn collect_estimates(
                 entry.push(RecordSig {
                     prob: allele_probs[i],
                     vartype: vartypes[i],
-                    sample: tumor_name.to_string()
+                    sample: tumor_name.to_string(),
                 });
             }
         }
@@ -187,9 +187,8 @@ pub(crate) fn collect_estimates(
                 blueprint["data"]["values"] = data;
                 if cutpoint_tmb == max_tmb {
                     blueprint["vconcat"][0]["encoding"]["y"]["scale"]["domain"] =
-                    json!([0.0, max_tmb]);
-                }
-                else {
+                        json!([0.0, max_tmb]);
+                } else {
                     blueprint["vconcat"][0]["encoding"]["y"]["scale"]["domain"] =
                         json!([cutpoint_tmb, max_tmb]);
                     blueprint["vconcat"][1]["encoding"]["y"]["scale"]["domain"] =
@@ -227,17 +226,17 @@ pub(crate) fn collect_estimates(
                     vaf: cutoff,
                     tmb,
                     vartype,
-                    sample
+                    sample,
                 });
             }
-            
+
             print_plot(
                 json!(plot_data),
                 include_str!("../../templates/plots/vaf_multi_bar.json"),
                 max_tmb,
                 max_tmb,
             )
-        },
+        }
         PlotMode::Hist => {
             let mut plot_data = Vec::new();
             // perform binning for histogram
@@ -276,7 +275,7 @@ pub(crate) fn collect_estimates(
                 cutpoint_tmb,
                 max_tmb,
             )
-        },
+        }
         PlotMode::Curve => {
             let mut plot_data = Vec::new();
             let mut max_tmbs = Vec::new();
@@ -316,7 +315,7 @@ pub(crate) fn collect_estimates(
                 max_tmb,
             )
         }
-    }       
+    }
 }
 
 #[derive(

--- a/templates/plots/vaf_multi_bar.json
+++ b/templates/plots/vaf_multi_bar.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+  "description": "Tumor mutational burden.",
+  "data": { "values": [] },
+  "vconcat": [
+    {
+      "mark": { "type": "bar", "clip": true },
+      "height": 87,
+      "encoding": {
+        "x": {"field": "sample", "type": "nominal", "axis": { "title": "", "format": ".2" , "labels":false, "ticks":false}},
+        "y": {"field": "tmb", "type": "quantitative", "axis": { "title": "mutations/Mb" }, "scale": {"domain": [0, 199.9], "nice": false}},
+        "color": {"field": "sample", "type": "nominal", "scale": { "scheme": "tableau20"}},
+        "column": {"field": "vartype", "type": "nominal", "spacing": 5}
+      }
+    }
+  ],
+  "config": {
+    "concat": {
+      "spacing": 5
+    }
+  }
+}
+  


### PR DESCRIPTION
This PR seeks to enhance the TMB plotting functionality towards a multi-sample barplot. 
 - Vartypes have been reduced to Signatures (T>C falls under the same category as A>G etc.), but the original code is still present - maybe it can be an optional choice which representation to use.
- For visibility, TMB in the multi-sample plot is shown for a minimal VAF value which can be chosen as a parameter.

This is just a first functional version to get a quick representation of multiple samples side by side.
