### PR TITLE
TMB plots for multiple samples

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,7 +6,6 @@
 use std::collections::HashMap;
 use std::convert::{From, TryFrom};
 use std::fs::File;
-use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -30,6 +29,8 @@ use crate::testcase;
 use crate::variants::evidence::realignment;
 use crate::variants::evidence::realignment::pairhmm::GapParams;
 use crate::variants::model::modes::generic::FlatPrior;
+use crate::variants::model::prior::CheckablePrior;
+use crate::variants::model::prior::{Inheritance, Prior};
 use crate::variants::model::{Contamination, VariantType};
 use crate::variants::sample::{estimate_alignment_properties, ProtocolStrandedness};
 use crate::variants::types::breakends::BreakendIndex;
@@ -80,14 +81,18 @@ pub enum Varlociraptor {
         about = "Perform estimations.",
         setting = structopt::clap::AppSettings::ColoredHelp,
     )]
-    #[structopt(
-        name = "estimate",
-        about = "Perform estimations.",
-        setting = structopt::clap::AppSettings::ColoredHelp,
-    )]
     Estimate {
         #[structopt(subcommand)]
         kind: EstimateKind,
+    },
+    #[structopt(
+        name = "plot",
+        about = "Create plots",
+        setting = structopt::clap::AppSettings::ColoredHelp,
+    )]
+    Plot {
+        #[structopt(subcommand)]
+        kind: PlotKind,
     },
 }
 
@@ -260,6 +265,33 @@ pub enum PreprocessKind {
         )]
         #[serde(default = "default_pairhmm_mode")]
         pairhmm_mode: String,
+    },
+}
+
+#[derive(Debug, StructOpt, Serialize, Deserialize, Clone)]
+pub enum PlotKind {
+    #[structopt(
+        name = "variant-calling-prior",
+        about = "Plot variant calling prior given a scenario. Plot is printed to STDOUT in Vega-lite format.",
+        usage = "varlociraptor plot variant-calling-prior --scenario scenario.yaml > plot.vl.json",
+        setting = structopt::clap::AppSettings::ColoredHelp,
+    )]
+    VariantCallingPrior {
+        #[structopt(
+            parse(from_os_str),
+            long = "scenario",
+            required = true,
+            help = "Variant calling scenario that configures the prior."
+        )]
+        scenario: PathBuf,
+        #[structopt(
+            long = "contig",
+            required = true,
+            help = "Contig to consider for ploidy information."
+        )]
+        contig: String,
+        #[structopt(long = "sample", required = true, help = "Sample to plot.")]
+        sample: String,
     },
 }
 
@@ -657,44 +689,22 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
                     let call_generic = |scenario: grammar::Scenario,
                                         observations: PathMap|
                      -> Result<()> {
-                        let mut contaminations = scenario.sample_info();
-                        let mut resolutions = scenario.sample_info();
-                        let mut sample_names = scenario.sample_info();
+                        let sample_infos = SampleInfos::try_from(&scenario)?;
+
+                        // record observation paths
                         let mut sample_observations = scenario.sample_info();
-
-                        // parse samples
-                        for (sample_name, sample) in scenario.samples().iter() {
-                            let contamination = if let Some(contamination) = sample.contamination()
-                            {
-                                let contaminant = scenario.idx(contamination.by()).ok_or(
-                                    errors::Error::InvalidContaminationSampleName {
-                                        name: sample_name.to_owned(),
-                                    },
-                                )?;
-                                Some(Contamination {
-                                    by: contaminant,
-                                    fraction: *contamination.fraction(),
-                                })
-                            } else {
-                                None
-                            };
-                            contaminations = contaminations.push(sample_name, contamination);
-                            resolutions = resolutions.push(sample_name, *sample.resolution());
-
+                        for (sample_name, _) in scenario.samples().iter() {
                             if let Some(obs) = observations.get(sample_name) {
                                 sample_observations =
                                     sample_observations.push(sample_name, Some(obs.to_owned()));
                             } else {
                                 sample_observations = sample_observations.push(sample_name, None);
                             }
-                            sample_names = sample_names.push(sample_name, sample_name.to_owned());
                         }
-
-                        let sample_names = sample_names.build();
                         let sample_observations = sample_observations.build();
 
                         for obs_sample_name in observations.keys() {
-                            if !sample_names.as_slice().contains(obs_sample_name) {
+                            if !sample_infos.names.as_slice().contains(obs_sample_name) {
                                 return Err(errors::Error::InvalidObservationSampleName {
                                     name: obs_sample_name.to_owned(),
                                 }
@@ -705,17 +715,37 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
                         let breakend_index =
                             BreakendIndex::new(sample_observations.first_not_none()?)?;
 
+                        let prior = Prior::builder()
+                            .ploidies(None)
+                            .universe(None)
+                            .uniform(sample_infos.uniform_prior)
+                            .germline_mutation_rate(sample_infos.germline_mutation_rates)
+                            .somatic_effective_mutation_rate(
+                                sample_infos.somatic_effective_mutation_rates,
+                            )
+                            .inheritance(sample_infos.inheritance)
+                            .genome_size(
+                                scenario
+                                    .species()
+                                    .as_ref()
+                                    .map_or(None, |species| *species.genome_size()),
+                            )
+                            .heterozygosity(scenario.species().as_ref().map_or(None, |species| {
+                                species.heterozygosity().map(|het| LogProb::from(Prob(het)))
+                            }))
+                            .build();
+
                         // setup caller
                         let caller = calling::variants::CallerBuilder::default()
-                            .samplenames(sample_names)
+                            .samplenames(sample_infos.names)
                             .observations(sample_observations)
                             .omit_strand_bias(omit_strand_bias)
                             .omit_read_orientation_bias(omit_read_orientation_bias)
                             .omit_read_position_bias(omit_read_position_bias)
                             .scenario(scenario)
-                            .prior(FlatPrior::new()) // TODO allow to define prior in the grammar
-                            .contaminations(contaminations.build())
-                            .resolutions(resolutions.build())
+                            .prior(prior)
+                            .contaminations(sample_infos.contaminations)
+                            .resolutions(sample_infos.resolutions)
                             .breakend_index(breakend_index)
                             .outbcf(output)
                             .build()
@@ -764,11 +794,7 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
                                     return Ok(());
                                 }
 
-                                let mut scenario_content = String::new();
-                                File::open(scenario)?.read_to_string(&mut scenario_content)?;
-
-                                let scenario: grammar::Scenario =
-                                    serde_yaml::from_str(&scenario_content)?;
+                                let scenario = grammar::Scenario::from_path(scenario)?;
 
                                 call_generic(scenario, sample_observations)?;
                             } else {
@@ -932,6 +958,52 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
                 cutoff as f64,
             )?,
         },
+        Varlociraptor::Plot { kind } => match kind {
+            PlotKind::VariantCallingPrior {
+                scenario,
+                contig,
+                sample,
+            } => {
+                let scenario = grammar::Scenario::from_path(scenario)?;
+                let sample_infos = SampleInfos::try_from(&scenario)?;
+
+                let mut universes = scenario.sample_info();
+                let mut ploidies = scenario.sample_info();
+                for (sample_name, sample) in scenario.samples().iter() {
+                    universes = universes.push(
+                        sample_name,
+                        sample.contig_universe(&contig, scenario.species())?,
+                    );
+                    ploidies = ploidies.push(
+                        sample_name,
+                        sample.contig_ploidy(&contig, scenario.species())?,
+                    );
+                }
+                let universes = universes.build();
+                let ploidies = ploidies.build();
+
+                let prior = Prior::builder()
+                    .ploidies(Some(ploidies))
+                    .universe(Some(universes))
+                    .uniform(sample_infos.uniform_prior)
+                    .germline_mutation_rate(sample_infos.germline_mutation_rates)
+                    .somatic_effective_mutation_rate(sample_infos.somatic_effective_mutation_rates)
+                    .inheritance(sample_infos.inheritance)
+                    .genome_size(
+                        scenario
+                            .species()
+                            .as_ref()
+                            .map_or(None, |species| *species.genome_size()),
+                    )
+                    .heterozygosity(scenario.species().as_ref().map_or(None, |species| {
+                        species.heterozygosity().map(|het| LogProb::from(Prob(het)))
+                    }))
+                    .build();
+                prior.check()?;
+
+                prior.plot(&sample, &sample_infos.names)?;
+            }
+        },
     }
     Ok(())
 }
@@ -948,5 +1020,102 @@ pub(crate) fn est_or_load_alignment_properties(
         )?)?)
     } else {
         estimate_alignment_properties(bam_file, omit_insert_size, allow_hardclips)
+    }
+}
+
+struct SampleInfos {
+    uniform_prior: grammar::SampleInfo<bool>,
+    contaminations: grammar::SampleInfo<Option<Contamination>>,
+    resolutions: grammar::SampleInfo<usize>,
+    germline_mutation_rates: grammar::SampleInfo<Option<f64>>,
+    somatic_effective_mutation_rates: grammar::SampleInfo<Option<f64>>,
+    inheritance: grammar::SampleInfo<Option<Inheritance>>,
+    names: grammar::SampleInfo<String>,
+}
+
+impl<'a> TryFrom<&'a grammar::Scenario> for SampleInfos {
+    type Error = anyhow::Error;
+
+    fn try_from(scenario: &grammar::Scenario) -> Result<Self> {
+        let mut contaminations = scenario.sample_info();
+        let mut resolutions = scenario.sample_info();
+        let mut sample_names = scenario.sample_info();
+        let mut germline_mutation_rates = scenario.sample_info();
+        let mut somatic_effective_mutation_rates = scenario.sample_info();
+        let mut inheritance = scenario.sample_info();
+        let mut uniform_prior = scenario.sample_info();
+
+        for (sample_name, sample) in scenario.samples().iter() {
+            let contamination = if let Some(contamination) = sample.contamination() {
+                let contaminant = scenario.idx(contamination.by()).ok_or(
+                    errors::Error::InvalidContaminationSampleName {
+                        name: sample_name.to_owned(),
+                    },
+                )?;
+                Some(Contamination {
+                    by: contaminant,
+                    fraction: *contamination.fraction(),
+                })
+            } else {
+                None
+            };
+            uniform_prior = uniform_prior.push(sample_name, sample.has_uniform_prior());
+            contaminations = contaminations.push(sample_name, contamination);
+            resolutions = resolutions.push(sample_name, *sample.resolution());
+            sample_names = sample_names.push(sample_name, sample_name.to_owned());
+            germline_mutation_rates = germline_mutation_rates.push(
+                sample_name,
+                sample.germline_mutation_rate(scenario.species()),
+            );
+            somatic_effective_mutation_rates = somatic_effective_mutation_rates.push(
+                sample_name,
+                sample.somatic_effective_mutation_rate(scenario.species()),
+            );
+            inheritance = inheritance.push(
+                sample_name,
+                if let Some(inheritance) = sample.inheritance() {
+                    let parent_idx = |parent| {
+                        scenario
+                            .idx(parent)
+                            .ok_or(errors::Error::InvalidInheritanceSampleName {
+                                name: sample_name.to_owned(),
+                            })
+                    };
+                    Some(match inheritance {
+                        grammar::Inheritance::Mendelian { from: parents } => {
+                            Inheritance::Mendelian {
+                                from: (parent_idx(&parents.0)?, parent_idx(&parents.1)?),
+                            }
+                        }
+                        grammar::Inheritance::Clonal {
+                            from: parent,
+                            somatic,
+                        } => Inheritance::Clonal {
+                            from: parent_idx(parent)?,
+                            somatic: *somatic,
+                        },
+                        grammar::Inheritance::Subclonal {
+                            from: parent,
+                            origin,
+                        } => Inheritance::Subclonal {
+                            from: parent_idx(parent)?,
+                            origin: *origin,
+                        },
+                    })
+                } else {
+                    None
+                },
+            );
+        }
+
+        Ok(SampleInfos {
+            uniform_prior: uniform_prior.build(),
+            contaminations: contaminations.build(),
+            resolutions: resolutions.build(),
+            germline_mutation_rates: germline_mutation_rates.build(),
+            somatic_effective_mutation_rates: somatic_effective_mutation_rates.build(),
+            inheritance: inheritance.build(),
+            names: sample_names.build(),
+        })
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,6 +6,7 @@
 use std::collections::HashMap;
 use std::convert::{From, TryFrom};
 use std::fs::File;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -29,8 +30,6 @@ use crate::testcase;
 use crate::variants::evidence::realignment;
 use crate::variants::evidence::realignment::pairhmm::GapParams;
 use crate::variants::model::modes::generic::FlatPrior;
-use crate::variants::model::prior::CheckablePrior;
-use crate::variants::model::prior::{Inheritance, Prior};
 use crate::variants::model::{Contamination, VariantType};
 use crate::variants::sample::{estimate_alignment_properties, ProtocolStrandedness};
 use crate::variants::types::breakends::BreakendIndex;
@@ -81,18 +80,14 @@ pub enum Varlociraptor {
         about = "Perform estimations.",
         setting = structopt::clap::AppSettings::ColoredHelp,
     )]
+    #[structopt(
+        name = "estimate",
+        about = "Perform estimations.",
+        setting = structopt::clap::AppSettings::ColoredHelp,
+    )]
     Estimate {
         #[structopt(subcommand)]
         kind: EstimateKind,
-    },
-    #[structopt(
-        name = "plot",
-        about = "Create plots",
-        setting = structopt::clap::AppSettings::ColoredHelp,
-    )]
-    Plot {
-        #[structopt(subcommand)]
-        kind: PlotKind,
     },
 }
 
@@ -269,33 +264,6 @@ pub enum PreprocessKind {
 }
 
 #[derive(Debug, StructOpt, Serialize, Deserialize, Clone)]
-pub enum PlotKind {
-    #[structopt(
-        name = "variant-calling-prior",
-        about = "Plot variant calling prior given a scenario. Plot is printed to STDOUT in Vega-lite format.",
-        usage = "varlociraptor plot variant-calling-prior --scenario scenario.yaml > plot.vl.json",
-        setting = structopt::clap::AppSettings::ColoredHelp,
-    )]
-    VariantCallingPrior {
-        #[structopt(
-            parse(from_os_str),
-            long = "scenario",
-            required = true,
-            help = "Variant calling scenario that configures the prior."
-        )]
-        scenario: PathBuf,
-        #[structopt(
-            long = "contig",
-            required = true,
-            help = "Contig to consider for ploidy information."
-        )]
-        contig: String,
-        #[structopt(long = "sample", required = true, help = "Sample to plot.")]
-        sample: String,
-    },
-}
-
-#[derive(Debug, StructOpt, Serialize, Deserialize, Clone)]
 pub enum EstimateKind {
     #[structopt(
         name = "tmb",
@@ -316,9 +284,9 @@ pub enum EstimateKind {
         #[structopt(
             long = "tumor-sample",
             default_value = "tumor",
-            help = "Name of the tumor sample in the given VCF/BCF."
+            help = "Name(s) of the tumor sample(s) in the given VCF/BCF. Multiple samples can be given when using the multibar plot mode."
         )]
-        tumor_sample: String,
+        tumor_sample: Vec<String>,
         #[structopt(
             long = "coding-genome-size",
             default_value = "3e7",
@@ -328,9 +296,15 @@ pub enum EstimateKind {
         #[structopt(
             long = "plot-mode",
             possible_values = &estimation::tumor_mutational_burden::PlotMode::iter().map(|v| v.into()).collect_vec(),
-            help = "How to plot (as stratified curve or as histogram)."
+            help = "How to plot (as stratified curve, histogram or multi-sample barplot)."
         )]
         mode: estimation::tumor_mutational_burden::PlotMode,
+        #[structopt(
+            long = "vaf-cutoff",
+            default_value = "0.2",
+            help = "Minimal variant allelic fraction to consider for mutli-sample barplot"
+        )]
+        cutoff: f64,
     },
 }
 
@@ -683,22 +657,44 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
                     let call_generic = |scenario: grammar::Scenario,
                                         observations: PathMap|
                      -> Result<()> {
-                        let sample_infos = SampleInfos::try_from(&scenario)?;
-
-                        // record observation paths
+                        let mut contaminations = scenario.sample_info();
+                        let mut resolutions = scenario.sample_info();
+                        let mut sample_names = scenario.sample_info();
                         let mut sample_observations = scenario.sample_info();
-                        for (sample_name, _) in scenario.samples().iter() {
+
+                        // parse samples
+                        for (sample_name, sample) in scenario.samples().iter() {
+                            let contamination = if let Some(contamination) = sample.contamination()
+                            {
+                                let contaminant = scenario.idx(contamination.by()).ok_or(
+                                    errors::Error::InvalidContaminationSampleName {
+                                        name: sample_name.to_owned(),
+                                    },
+                                )?;
+                                Some(Contamination {
+                                    by: contaminant,
+                                    fraction: *contamination.fraction(),
+                                })
+                            } else {
+                                None
+                            };
+                            contaminations = contaminations.push(sample_name, contamination);
+                            resolutions = resolutions.push(sample_name, *sample.resolution());
+
                             if let Some(obs) = observations.get(sample_name) {
                                 sample_observations =
                                     sample_observations.push(sample_name, Some(obs.to_owned()));
                             } else {
                                 sample_observations = sample_observations.push(sample_name, None);
                             }
+                            sample_names = sample_names.push(sample_name, sample_name.to_owned());
                         }
+
+                        let sample_names = sample_names.build();
                         let sample_observations = sample_observations.build();
 
                         for obs_sample_name in observations.keys() {
-                            if !sample_infos.names.as_slice().contains(obs_sample_name) {
+                            if !sample_names.as_slice().contains(obs_sample_name) {
                                 return Err(errors::Error::InvalidObservationSampleName {
                                     name: obs_sample_name.to_owned(),
                                 }
@@ -709,37 +705,17 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
                         let breakend_index =
                             BreakendIndex::new(sample_observations.first_not_none()?)?;
 
-                        let prior = Prior::builder()
-                            .ploidies(None)
-                            .universe(None)
-                            .uniform(sample_infos.uniform_prior)
-                            .germline_mutation_rate(sample_infos.germline_mutation_rates)
-                            .somatic_effective_mutation_rate(
-                                sample_infos.somatic_effective_mutation_rates,
-                            )
-                            .inheritance(sample_infos.inheritance)
-                            .genome_size(
-                                scenario
-                                    .species()
-                                    .as_ref()
-                                    .map_or(None, |species| *species.genome_size()),
-                            )
-                            .heterozygosity(scenario.species().as_ref().map_or(None, |species| {
-                                species.heterozygosity().map(|het| LogProb::from(Prob(het)))
-                            }))
-                            .build();
-
                         // setup caller
                         let caller = calling::variants::CallerBuilder::default()
-                            .samplenames(sample_infos.names)
+                            .samplenames(sample_names)
                             .observations(sample_observations)
                             .omit_strand_bias(omit_strand_bias)
                             .omit_read_orientation_bias(omit_read_orientation_bias)
                             .omit_read_position_bias(omit_read_position_bias)
                             .scenario(scenario)
-                            .prior(prior)
-                            .contaminations(sample_infos.contaminations)
-                            .resolutions(sample_infos.resolutions)
+                            .prior(FlatPrior::new()) // TODO allow to define prior in the grammar
+                            .contaminations(contaminations.build())
+                            .resolutions(resolutions.build())
                             .breakend_index(breakend_index)
                             .outbcf(output)
                             .build()
@@ -788,7 +764,11 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
                                     return Ok(());
                                 }
 
-                                let scenario = grammar::Scenario::from_path(scenario)?;
+                                let mut scenario_content = String::new();
+                                File::open(scenario)?.read_to_string(&mut scenario_content)?;
+
+                                let scenario: grammar::Scenario =
+                                    serde_yaml::from_str(&scenario_content)?;
 
                                 call_generic(scenario, sample_observations)?;
                             } else {
@@ -943,58 +923,14 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
                 tumor_sample,
                 coding_genome_size,
                 mode,
-            } => estimation::tumor_mutational_burden::estimate(
+                cutoff,
+            } => estimation::tumor_mutational_burden::collect_estimates(
                 &somatic_tumor_events,
                 &tumor_sample,
                 coding_genome_size as u64,
                 mode,
+                cutoff as f64,
             )?,
-        },
-        Varlociraptor::Plot { kind } => match kind {
-            PlotKind::VariantCallingPrior {
-                scenario,
-                contig,
-                sample,
-            } => {
-                let scenario = grammar::Scenario::from_path(scenario)?;
-                let sample_infos = SampleInfos::try_from(&scenario)?;
-
-                let mut universes = scenario.sample_info();
-                let mut ploidies = scenario.sample_info();
-                for (sample_name, sample) in scenario.samples().iter() {
-                    universes = universes.push(
-                        sample_name,
-                        sample.contig_universe(&contig, scenario.species())?,
-                    );
-                    ploidies = ploidies.push(
-                        sample_name,
-                        sample.contig_ploidy(&contig, scenario.species())?,
-                    );
-                }
-                let universes = universes.build();
-                let ploidies = ploidies.build();
-
-                let prior = Prior::builder()
-                    .ploidies(Some(ploidies))
-                    .universe(Some(universes))
-                    .uniform(sample_infos.uniform_prior)
-                    .germline_mutation_rate(sample_infos.germline_mutation_rates)
-                    .somatic_effective_mutation_rate(sample_infos.somatic_effective_mutation_rates)
-                    .inheritance(sample_infos.inheritance)
-                    .genome_size(
-                        scenario
-                            .species()
-                            .as_ref()
-                            .map_or(None, |species| *species.genome_size()),
-                    )
-                    .heterozygosity(scenario.species().as_ref().map_or(None, |species| {
-                        species.heterozygosity().map(|het| LogProb::from(Prob(het)))
-                    }))
-                    .build();
-                prior.check()?;
-
-                prior.plot(&sample, &sample_infos.names)?;
-            }
         },
     }
     Ok(())
@@ -1012,102 +948,5 @@ pub(crate) fn est_or_load_alignment_properties(
         )?)?)
     } else {
         estimate_alignment_properties(bam_file, omit_insert_size, allow_hardclips)
-    }
-}
-
-struct SampleInfos {
-    uniform_prior: grammar::SampleInfo<bool>,
-    contaminations: grammar::SampleInfo<Option<Contamination>>,
-    resolutions: grammar::SampleInfo<usize>,
-    germline_mutation_rates: grammar::SampleInfo<Option<f64>>,
-    somatic_effective_mutation_rates: grammar::SampleInfo<Option<f64>>,
-    inheritance: grammar::SampleInfo<Option<Inheritance>>,
-    names: grammar::SampleInfo<String>,
-}
-
-impl<'a> TryFrom<&'a grammar::Scenario> for SampleInfos {
-    type Error = anyhow::Error;
-
-    fn try_from(scenario: &grammar::Scenario) -> Result<Self> {
-        let mut contaminations = scenario.sample_info();
-        let mut resolutions = scenario.sample_info();
-        let mut sample_names = scenario.sample_info();
-        let mut germline_mutation_rates = scenario.sample_info();
-        let mut somatic_effective_mutation_rates = scenario.sample_info();
-        let mut inheritance = scenario.sample_info();
-        let mut uniform_prior = scenario.sample_info();
-
-        for (sample_name, sample) in scenario.samples().iter() {
-            let contamination = if let Some(contamination) = sample.contamination() {
-                let contaminant = scenario.idx(contamination.by()).ok_or(
-                    errors::Error::InvalidContaminationSampleName {
-                        name: sample_name.to_owned(),
-                    },
-                )?;
-                Some(Contamination {
-                    by: contaminant,
-                    fraction: *contamination.fraction(),
-                })
-            } else {
-                None
-            };
-            uniform_prior = uniform_prior.push(sample_name, sample.has_uniform_prior());
-            contaminations = contaminations.push(sample_name, contamination);
-            resolutions = resolutions.push(sample_name, *sample.resolution());
-            sample_names = sample_names.push(sample_name, sample_name.to_owned());
-            germline_mutation_rates = germline_mutation_rates.push(
-                sample_name,
-                sample.germline_mutation_rate(scenario.species()),
-            );
-            somatic_effective_mutation_rates = somatic_effective_mutation_rates.push(
-                sample_name,
-                sample.somatic_effective_mutation_rate(scenario.species()),
-            );
-            inheritance = inheritance.push(
-                sample_name,
-                if let Some(inheritance) = sample.inheritance() {
-                    let parent_idx = |parent| {
-                        scenario
-                            .idx(parent)
-                            .ok_or(errors::Error::InvalidInheritanceSampleName {
-                                name: sample_name.to_owned(),
-                            })
-                    };
-                    Some(match inheritance {
-                        grammar::Inheritance::Mendelian { from: parents } => {
-                            Inheritance::Mendelian {
-                                from: (parent_idx(&parents.0)?, parent_idx(&parents.1)?),
-                            }
-                        }
-                        grammar::Inheritance::Clonal {
-                            from: parent,
-                            somatic,
-                        } => Inheritance::Clonal {
-                            from: parent_idx(parent)?,
-                            somatic: *somatic,
-                        },
-                        grammar::Inheritance::Subclonal {
-                            from: parent,
-                            origin,
-                        } => Inheritance::Subclonal {
-                            from: parent_idx(parent)?,
-                            origin: *origin,
-                        },
-                    })
-                } else {
-                    None
-                },
-            );
-        }
-
-        Ok(SampleInfos {
-            uniform_prior: uniform_prior.build(),
-            contaminations: contaminations.build(),
-            resolutions: resolutions.build(),
-            germline_mutation_rates: germline_mutation_rates.build(),
-            somatic_effective_mutation_rates: somatic_effective_mutation_rates.build(),
-            inheritance: inheritance.build(),
-            names: sample_names.build(),
-        })
     }
 }

--- a/src/estimation/tumor_mutational_burden.rs
+++ b/src/estimation/tumor_mutational_burden.rs
@@ -48,19 +48,28 @@ struct TMB {
 struct TMBStrat {
     min_vaf: f64,
     tmb: f64,
-    vartype: Vartype,
+    vartype: Signature,
 }
 
 #[derive(Debug, Clone, Serialize)]
 struct TMBBin {
     vaf: f64,
     tmb: f64,
-    vartype: Vartype,
+    vartype: Signature,
 }
 
-struct Record {
+#[derive(Debug, Clone, Serialize)]
+struct TMBMultiBar {
+    vaf: f64,
+    tmb: f64,
+    vartype: Signature,
+    sample: String,
+}
+
+struct RecordSig {
     prob: LogProb,
-    vartype: Vartype,
+    vartype: Signature,
+    sample: String,
 }
 
 #[derive(
@@ -79,22 +88,28 @@ struct Record {
 pub enum PlotMode {
     Hist,
     Curve,
+    Multibar,
 }
 
-/// Estimate tumor mutational burden based on Varlociraptor calls from STDIN and print result to STDOUT.
-pub(crate) fn estimate(
+pub(crate) fn collect_estimates(
     somatic_tumor_events: &[String],
-    tumor_name: &str,
+    tumor_names: &[String],
     coding_genome_size: u64,
     mode: PlotMode,
+    cutoff: f64,
 ) -> Result<()> {
     let mut bcf = bcf::Reader::from_stdin()?;
     let header = bcf.header().to_owned();
 
-    let tumor_id = bcf
-        .header()
-        .sample_id(tumor_name.as_bytes())
-        .unwrap_or_else(|| panic!("Sample {} not found", tumor_name)); // TODO throw a proper error
+    let mut tumor_ids = BTreeMap::new();
+
+    for t in tumor_names {
+        let tumor_id = bcf
+            .header()
+            .sample_id(t.as_bytes())
+            .unwrap_or_else(|| panic!("Sample {} not found", t));
+        tumor_ids.insert(t, tumor_id);
+    }
 
     let mut tmb = BTreeMap::new();
     'records: loop {
@@ -107,8 +122,11 @@ pub(crate) fn estimate(
         let contig = str::from_utf8(header.rid2name(rec.rid().unwrap()).unwrap())?;
         let vcfpos = rec.pos() + 1;
         // obtain VAF estimates (do it here already to work around a segfault in htslib)
-        let vafs = rec.format(b"AF").float()?[tumor_id].to_owned();
-
+        let mut vafmap = BTreeMap::new();
+        for (name, id) in &tumor_ids {
+            let vafs = rec.format(b"AF").float()?[*id].to_owned();
+            vafmap.insert(name, vafs);
+        }
         if !is_valid_variant(&mut rec)? {
             info!(
                 "Skipping variant {}:{} because it is not coding.",
@@ -137,19 +155,21 @@ pub(crate) fn estimate(
                 continue 'records;
             }
         }
-        let vartypes = vartypes(&rec);
+        let vartypes = signatures(&rec);
 
         // push into TMB function
-        for i in 0..alt_allele_count {
-            let vaf = AlleleFreq(vafs[i] as f64);
-            let entry = tmb.entry(vaf).or_insert_with(Vec::new);
-            entry.push(Record {
-                prob: allele_probs[i],
-                vartype: vartypes[i],
-            });
+        for (tumor_name, _) in &tumor_ids {
+            for i in 0..alt_allele_count {
+                let vaf = AlleleFreq(vafmap.get(tumor_name).unwrap()[i] as f64);
+                let entry = tmb.entry(vaf).or_insert_with(Vec::new);
+                entry.push(RecordSig {
+                    prob: allele_probs[i],
+                    vartype: vartypes[i],
+                    sample: tumor_name.to_string(),
+                });
+            }
         }
     }
-
     if tmb.is_empty() {
         return Err(errors::Error::NoRecordsFound.into());
     }
@@ -165,10 +185,15 @@ pub(crate) fn estimate(
             let mut blueprint = serde_json::from_str(blueprint)?;
             if let Value::Object(ref mut blueprint) = blueprint {
                 blueprint["data"]["values"] = data;
-                blueprint["vconcat"][0]["encoding"]["y"]["scale"]["domain"] =
-                    json!([cutpoint_tmb, max_tmb]);
-                blueprint["vconcat"][1]["encoding"]["y"]["scale"]["domain"] =
-                    json!([0.0, cutpoint_tmb]);
+                if cutpoint_tmb == max_tmb {
+                    blueprint["vconcat"][0]["encoding"]["y"]["scale"]["domain"] =
+                        json!([0.0, max_tmb]);
+                } else {
+                    blueprint["vconcat"][0]["encoding"]["y"]["scale"]["domain"] =
+                        json!([cutpoint_tmb, max_tmb]);
+                    blueprint["vconcat"][1]["encoding"]["y"]["scale"]["domain"] =
+                        json!([0.0, cutpoint_tmb]);
+                }
                 // print to STDOUT
                 println!("{}", serde_json::to_string_pretty(blueprint)?);
                 Ok(())
@@ -180,6 +205,38 @@ pub(crate) fn estimate(
     let min_vafs = linspace(0.0, 1.0, 100).map(AlleleFreq);
 
     match mode {
+        PlotMode::Multibar => {
+            let mut plot_data = Vec::new();
+            let mut max_tmb = 0.0;
+            // calculate TMB function (expected number of somatic variants per minimum allele frequency)
+            let groups = tmb
+                .range(AlleleFreq(cutoff)..AlleleFreq(1.0))
+                .map(|(_, records)| records)
+                .flatten()
+                .map(|record| ((record.vartype, record.sample.clone()), record.prob))
+                .into_group_map();
+
+            for ((vartype, sample), probs) in groups {
+                let tmb = calc_tmb(&probs);
+                if tmb > max_tmb {
+                    max_tmb = tmb;
+                }
+
+                plot_data.push(TMBMultiBar {
+                    vaf: cutoff,
+                    tmb,
+                    vartype,
+                    sample,
+                });
+            }
+
+            print_plot(
+                json!(plot_data),
+                include_str!("../../templates/plots/vaf_multi_bar.json"),
+                max_tmb,
+                max_tmb,
+            )
+        }
         PlotMode::Hist => {
             let mut plot_data = Vec::new();
             // perform binning for histogram
@@ -319,6 +376,81 @@ pub(crate) enum Vartype {
     #[strum(serialize = "T>G")]
     #[serde(rename = "T>G")]
     TG,
+}
+
+#[derive(
+    Display,
+    Debug,
+    Clone,
+    Copy,
+    Serialize,
+    Deserialize,
+    EnumString,
+    EnumIter,
+    IntoStaticStr,
+    PartialEq,
+    Hash,
+    Eq,
+)]
+pub(crate) enum Signature {
+    DEL,
+    INS,
+    INV,
+    DUP,
+    BND,
+    MNV,
+    Complex,
+    #[strum(serialize = "C>A", serialize = "G>T")]
+    #[serde(rename = "C>A")]
+    CA,
+    #[strum(serialize = "C>G", serialize = "G>C")]
+    #[serde(rename = "C>G")]
+    CG,
+    #[strum(serialize = "C>T", serialize = "G>A")]
+    #[serde(rename = "C>T")]
+    CT,
+    #[strum(serialize = "T>A", serialize = "A>T")]
+    #[serde(rename = "T>A")]
+    TA,
+    #[strum(serialize = "T>C", serialize = "A>G")]
+    #[serde(rename = "T>C")]
+    TC,
+    #[strum(serialize = "T>G", serialize = "A>C")]
+    #[serde(rename = "T>G")]
+    TG,
+}
+
+pub(crate) fn signatures(record: &bcf::Record) -> Vec<Signature> {
+    let ref_allele = record.alleles()[0];
+    record.alleles()[1..]
+        .iter()
+        .map(|alt_allele| {
+            if alt_allele == b"<DEL>" {
+                Signature::DEL
+            } else if alt_allele == b"<INV>" {
+                Signature::INV
+            } else if alt_allele == b"<DUP>" {
+                Signature::DUP
+            } else if alt_allele == b"<BND>" {
+                Signature::BND
+            } else if ref_allele.len() == 1 && alt_allele.len() == 1 {
+                Signature::from_str(&format!(
+                    "{}>{}",
+                    str::from_utf8(ref_allele).unwrap(),
+                    str::from_utf8(alt_allele).unwrap()
+                ))
+                .unwrap()
+            } else if ref_allele.len() > 1 && alt_allele.len() == 1 {
+                Signature::DEL
+            } else if ref_allele.len() == 1 && alt_allele.len() > 1 {
+                Signature::INS
+            } else if ref_allele.len() == alt_allele.len() && ref_allele.len() > 1 {
+                Signature::MNV
+            } else {
+                Signature::Complex
+            }
+        })
+        .collect_vec()
 }
 
 pub(crate) fn vartypes(record: &bcf::Record) -> Vec<Vartype> {

--- a/src/estimation/tumor_mutational_burden.rs
+++ b/src/estimation/tumor_mutational_burden.rs
@@ -161,7 +161,9 @@ pub(crate) fn collect_estimates(
         for (tumor_name, _) in &tumor_ids {
             for i in 0..alt_allele_count {
                 // if all alt_alleles are NaN, the list will only contain one NaN, so check for size
-                if i == vafmap.get(tumor_name).unwrap().len() && vafmap.get(tumor_name).unwrap()[0].is_nan() {
+                if i == vafmap.get(tumor_name).unwrap().len()
+                    && vafmap.get(tumor_name).unwrap()[0].is_nan()
+                {
                     continue;
                 }
                 let vaf = vafmap.get(tumor_name).unwrap()[i] as f64;

--- a/src/estimation/tumor_mutational_burden.rs
+++ b/src/estimation/tumor_mutational_burden.rs
@@ -160,8 +160,12 @@ pub(crate) fn collect_estimates(
         // push into TMB function
         for (tumor_name, _) in &tumor_ids {
             for i in 0..alt_allele_count {
-                let vaf = AlleleFreq(vafmap.get(tumor_name).unwrap()[i] as f64);
-                let entry = tmb.entry(vaf).or_insert_with(Vec::new);
+                let vaf = vafmap.get(tumor_name).unwrap()[i] as f64;
+                if vaf.is_nan() {
+                    continue;
+                }
+                let allele_freq = AlleleFreq(vaf);
+                let entry = tmb.entry(allele_freq).or_insert_with(Vec::new);
                 entry.push(RecordSig {
                     prob: allele_probs[i],
                     vartype: vartypes[i],

--- a/src/estimation/tumor_mutational_burden.rs
+++ b/src/estimation/tumor_mutational_burden.rs
@@ -160,6 +160,10 @@ pub(crate) fn collect_estimates(
         // push into TMB function
         for (tumor_name, _) in &tumor_ids {
             for i in 0..alt_allele_count {
+                // if all alt_alleles are NaN, the list will only contain one NaN, so check for size
+                if i == vafmap.get(tumor_name).unwrap().len() && vafmap.get(tumor_name).unwrap()[0].is_nan() {
+                    continue;
+                }
                 let vaf = vafmap.get(tumor_name).unwrap()[i] as f64;
                 if vaf.is_nan() {
                     continue;

--- a/templates/plots/vaf_curve_strat.json
+++ b/templates/plots/vaf_curve_strat.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
-    "description": "Tumor mutational burden.",
+    "description": "Mutational burden.",
     "data": { "values": [] },
     "vconcat": [
       {
@@ -8,7 +8,7 @@
         "height": 87,
         "encoding": {
           "x": {"field": "min_vaf", "type": "quantitative", "axis": { "title": "", "labels": false, "ticks": false }},
-          "y": {"field": "tmb", "type": "quantitative", "axis": { "title": "" }, "stack": true, "scale": {"domain": [200, 420], "nice": false}},
+          "y": {"field": "mb", "type": "quantitative", "axis": { "title": "" }, "stack": true, "scale": {"domain": [200, 420], "nice": false}},
           "color": {"field": "vartype", "type": "nominal", "scale": { "scheme": "tableau20"}}
         }
       },
@@ -17,7 +17,7 @@
         "height": 143,
         "encoding": {
           "x": {"field": "min_vaf", "type": "quantitative", "axis": { "title": "minimum VAF" }},
-          "y": {"field": "tmb", "type": "quantitative", "axis": { "title": "mutations/Mb" }, "stack": true, "scale": {"domain": [0, 199.9], "nice": false}},
+          "y": {"field": "mb", "type": "quantitative", "axis": { "title": "mutations/Mb" }, "stack": true, "scale": {"domain": [0, 199.9], "nice": false}},
           "color": {"field": "vartype", "type": "nominal", "scale": { "scheme": "tableau20"}}
         }
       }

--- a/templates/plots/vaf_hist.json
+++ b/templates/plots/vaf_hist.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
-  "description": "Tumor mutational burden.",
+  "description": "Mutational burden.",
   "data": { "values": [] },
   "vconcat": [
     {
@@ -8,7 +8,7 @@
       "height": 87,
       "encoding": {
         "x": {"field": "vaf", "type": "ordinal", "axis": { "title": "", "labels": false, "ticks": false }},
-        "y": {"field": "tmb", "type": "quantitative", "axis": { "title": "" }, "scale": {"domain": [200, 420], "nice": false}},
+        "y": {"field": "mb", "type": "quantitative", "axis": { "title": "" }, "scale": {"domain": [200, 420], "nice": false}},
         "color": {"field": "vartype", "type": "nominal", "scale": { "scheme": "tableau20"}}
       }
     },
@@ -17,7 +17,7 @@
       "height": 143,
       "encoding": {
         "x": {"field": "vaf", "type": "ordinal", "axis": { "title": "VAF", "format": ".2" }},
-        "y": {"field": "tmb", "type": "quantitative", "axis": { "title": "mutations/Mb" }, "scale": {"domain": [0, 199.9], "nice": false}},
+        "y": {"field": "mb", "type": "quantitative", "axis": { "title": "mutations/Mb" }, "scale": {"domain": [0, 199.9], "nice": false}},
         "color": {"field": "vartype", "type": "nominal", "scale": { "scheme": "tableau20"}}
       }
     }

--- a/templates/plots/vaf_multi_bar.json
+++ b/templates/plots/vaf_multi_bar.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+  "description": "Tumor mutational burden.",
+  "data": { "values": [] },
+  "vconcat": [
+    {
+      "mark": { "type": "bar", "clip": true },
+      "height": 87,
+      "encoding": {
+        "x": {"field": "sample", "type": "nominal", "axis": { "title": "", "format": ".2" , "labels":false, "ticks":false}},
+        "y": {"field": "tmb", "type": "quantitative", "axis": { "title": "mutations/Mb" }, "scale": {"domain": [0, 199.9], "nice": false}},
+        "color": {"field": "sample", "type": "nominal", "scale": { "scheme": "tableau20"}},
+        "column": {"field": "vartype", "type": "nominal", "spacing": 5}
+      }
+    }
+  ],
+  "config": {
+    "concat": {
+      "spacing": 5
+    }
+  }
+}
+  

--- a/templates/plots/vaf_multi_bar.json
+++ b/templates/plots/vaf_multi_bar.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
-  "description": "Tumor mutational burden.",
+  "description": "Mutational burden.",
   "data": { "values": [] },
   "vconcat": [
     {
@@ -8,7 +8,7 @@
       "height": 87,
       "encoding": {
         "x": {"field": "sample", "type": "nominal", "axis": { "title": "", "format": ".2" , "labels":false, "ticks":false}},
-        "y": {"field": "tmb", "type": "quantitative", "axis": { "title": "mutations/Mb" }, "scale": {"domain": [0, 199.9], "nice": false}},
+        "y": {"field": "mb", "type": "quantitative", "axis": { "title": "mutations/Mb" }, "scale": {"domain": [0, 199.9], "nice": false}},
         "color": {"field": "sample", "type": "nominal", "scale": { "scheme": "tableau20"}},
         "column": {"field": "vartype", "type": "nominal", "spacing": 5}
       }


### PR DESCRIPTION
This PR seeks to enhance the TMB plotting functionality towards a multi-sample barplot. 
 - Vartypes have been reduced to Signatures (T>C falls under the same category as A>G etc.), but the original code is still present - maybe it can be an optional choice which representation to use.
- For visibility, TMB in the multi-sample plot is shown for a minimal VAF value which can be chosen as a parameter.

This is just a first functional version to get a quick representation of multiple samples side by side.
