### PR TITLE
Add ready-to-code option with gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,5 @@
+image:
+  file: Dockerfile
+
+tasks:
+  - before: micromamba activate varlociraptor

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,5 @@ RUN sudo apt-get install --yes libgsl0-dev
 USER gitpod
 ENV SHELL /bin/bash
 RUN wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
-RUN ./bin/micromamba create -n varlociraptor samtools -c bioconda
+RUN ./bin/micromamba create -n varlociraptor samtools -c bioconda -c conda-forge
 RUN yes | ./bin/micromamba shell init -s bash -p /home/gitpod/micromamba

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM gitpod/workspace-full
+RUN sudo apt-get install --yes libgsl0-dev
+
+USER gitpod
+ENV SHELL /bin/bash
+RUN wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
+RUN ./bin/micromamba create -n varlociraptor samtools -c bioconda
+RUN yes | ./bin/micromamba shell init -s bash -p /home/gitpod/micromamba

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Codecov](https://img.shields.io/codecov/c/github/varlociraptor/varlociraptor/master.svg?label=test%20coverage)](https://codecov.io/gh/varlociraptor/varlociraptor)
 [![API docs](https://img.shields.io/badge/API-documentation-blue.svg)](https://docs.rs/varlociraptor)
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/varlociraptor/varlociraptor)
 
 Varlociraptor implements a novel, unified fully uncertainty-aware approach to genomic variant calling in arbitrary scenarios. 
 


### PR DESCRIPTION
[gitpod](https://gitpod.io/workspaces/) itself supplies a pretty good summary for this PR:
> This PR implements a fully-automated development setup using Gitpod.io, an
> online IDE for GitLab, GitHub, and Bitbucket that enables Dev-Environments-As-Code.
> This makes it easy for anyone to get a ready-to-code workspace for any branch,
> issue or pull request almost instantly with a single click.

The dependencies needed for tests (i.e. samtools) are contained in a pre-built environment with the name `varlociraptor` that is automatically activated in the first opened terminal. When opening a new terminal you can activate the environment manually with `micromamba activate varlociraptor`.