### PR TITLE
decode_phred: ensure quoting of description in changed header lines

### DIFF
--- a/src/conversion/decode_phred.rs
+++ b/src/conversion/decode_phred.rs
@@ -28,7 +28,7 @@ pub(crate) fn decode_phred() -> Result<()> {
         header.push_record(
             format!(
                 "##INFO=<ID={},Number=A,Type=Float,\
-                 Description={}>",
+                 Description=\"{}\">",
                 id, description
             )
             .as_bytes(),


### PR DESCRIPTION
Otherwise, descriptions containing commas will lead to invalid header lines, as commas will be interpreted as field separators in the header line.