### PR TITLE
Fix compiler warning

### DIFF
--- a/src/variants/model/prior.rs
+++ b/src/variants/model/prior.rs
@@ -747,11 +747,11 @@ impl Prior {
             // TODO For the future:
             // case 1: no separation in the first meiotic split (choose from all chromosomes of that parent)
             // case 2: no separation in the second meiotic split (duplicate a parental chromosome)
-            panic!(format!(
+            panic!(
                 "ploidies of child and parents do not match ({}, {} => {}) chromosome duplication events \
                     (e.g. trisomy) are not yet supported by the mendelian inheritance model of varlociraptor", 
                 source_ploidy.0, source_ploidy.1, target_ploidy
-            ));
+            );
         }
     }
 


### PR DESCRIPTION
Analog to [this one at rust-bio](https://github.com/rust-bio/rust-bio/pull/430#event-4805686901), just with the `panic!` macro:

> Just a quick fix of for `#[warn(non_fmt_panic)]`. Looks like the `format!` macro should be avoided inside the `assert!` >as shown [here](https://doc.rust-lang.org/std/macro.assert.html#custom-messages) in the example for custom error >messages with `assert!`.  