### PR TITLE
chore: Address some clippy lints

### DIFF
--- a/src/calling/variants/mod.rs
+++ b/src/calling/variants/mod.rs
@@ -212,9 +212,9 @@ impl Call {
                         }),
                         false,
                         |(item, _count)| {
-                            if item.starts_with("N") {
+                            if item.starts_with('N') {
                                 2
-                            } else if item.starts_with("E") {
+                            } else if item.starts_with('E') {
                                 1
                             } else {
                                 0
@@ -239,9 +239,9 @@ impl Call {
                         }),
                         false,
                         |(item, _count)| {
-                            if item.starts_with("N") {
+                            if item.starts_with('N') {
                                 2
-                            } else if item.starts_with("E") {
+                            } else if item.starts_with('E') {
                                 1
                             } else {
                                 0

--- a/src/calling/variants/mod.rs
+++ b/src/calling/variants/mod.rs
@@ -454,10 +454,10 @@ impl VariantBuilder {
                     .svlen(Some(svlen))
                     .svtype(Some(b"INS".to_vec()))
             }
-            model::Variant::SNV(base) => self
+            model::Variant::Snv(base) => self
                 .ref_allele(chrom_seq.unwrap()[start..start + 1].to_ascii_uppercase())
                 .alt_allele(vec![*base].to_ascii_uppercase()),
-            model::Variant::MNV(bases) => self
+            model::Variant::Mnv(bases) => self
                 .ref_allele(chrom_seq.unwrap()[start..start + bases.len()].to_ascii_uppercase())
                 .alt_allele(bases.to_ascii_uppercase()),
             model::Variant::Breakend {

--- a/src/calling/variants/preprocessing/mod.rs
+++ b/src/calling/variants/preprocessing/mod.rs
@@ -252,12 +252,12 @@ impl<R: realignment::Realigner + Clone + std::marker::Send + std::marker::Sync>
                 .unwrap();
 
                 let chrom_seq = self.reference_buffer.seq(&work_item.chrom)?;
-                let pileup = self.process_variant(&variant, &work_item, sample)?.unwrap(); // only breakends can lead to None, and they are handled below
+                let pileup = self.process_variant(variant, &work_item, sample)?.unwrap(); // only breakends can lead to None, and they are handled below
 
                 // add variant information
                 call.variant = Some(
                     VariantBuilder::default()
-                        .variant(&variant, work_item.start as usize, Some(chrom_seq.as_ref()))
+                        .variant(variant, work_item.start as usize, Some(chrom_seq.as_ref()))
                         .observations(Some(pileup))
                         .build()
                         .unwrap(),

--- a/src/calling/variants/preprocessing/mod.rs
+++ b/src/calling/variants/preprocessing/mod.rs
@@ -331,13 +331,13 @@ impl<R: realignment::Realigner + Clone + std::marker::Send + std::marker::Sync>
         let start = work_item.start as usize;
 
         Ok(Some(match variant {
-            model::Variant::SNV(alt) => sample.extract_observations(&variants::types::SNV::new(
+            model::Variant::Snv(alt) => sample.extract_observations(&variants::types::Snv::new(
                 locus(),
                 self.reference_buffer.seq(&work_item.chrom)?[start],
                 *alt,
                 self.realigner.clone(),
             ))?,
-            model::Variant::MNV(alt) => sample.extract_observations(&variants::types::MNV::new(
+            model::Variant::Mnv(alt) => sample.extract_observations(&variants::types::Mnv::new(
                 locus(),
                 self.reference_buffer.seq(&work_item.chrom)?[start..start + alt.len()].to_owned(),
                 alt.to_owned(),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -774,9 +774,9 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
                                 scenario
                                     .species()
                                     .as_ref()
-                                    .map_or(None, |species| *species.genome_size()),
+                                    .and_then(|species| *species.genome_size()),
                             )
-                            .heterozygosity(scenario.species().as_ref().map_or(None, |species| {
+                            .heterozygosity(scenario.species().as_ref().and_then(|species| {
                                 species.heterozygosity().map(|het| LogProb::from(Prob(het)))
                             }))
                             .variant_type_fractions(scenario.variant_type_fractions())
@@ -820,7 +820,7 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
                                         let options = calling::variants::preprocessing::read_preprocess_options(obspath)?;
                                         let preprocess_input = options.preprocess_input();
                                         testcase_builder = testcase_builder.register_sample(
-                                            &sample_name,
+                                            sample_name,
                                             preprocess_input.bam,
                                             options,
                                         )?;
@@ -1044,9 +1044,9 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
                         scenario
                             .species()
                             .as_ref()
-                            .map_or(None, |species| *species.genome_size()),
+                            .and_then(|species| *species.genome_size()),
                     )
-                    .heterozygosity(scenario.species().as_ref().map_or(None, |species| {
+                    .heterozygosity(scenario.species().as_ref().and_then(|species| {
                         species.heterozygosity().map(|het| LogProb::from(Prob(het)))
                     }))
                     .build();

--- a/src/conversion/decode_phred.rs
+++ b/src/conversion/decode_phred.rs
@@ -45,7 +45,7 @@ pub(crate) fn decode_phred() -> Result<()> {
                     .iter()
                     .map(|v| *Prob::from(PHREDProb(*v as f64)) as f32)
                     .collect_vec();
-                record.push_info_float(&id, &converted)?;
+                record.push_info_float(id, &converted)?;
             }
         }
         outbcf.write(&record)?;

--- a/src/estimation/effective_mutation_rate.rs
+++ b/src/estimation/effective_mutation_rate.rs
@@ -22,11 +22,13 @@ pub(crate) struct Estimate {
 }
 
 impl Estimate {
+    #[allow(dead_code)]
     pub(crate) fn effective_mutation_rate(&self) -> f64 {
         self.slope
     }
 }
 
+#[allow(dead_code)]
 pub(crate) fn estimate<F: IntoIterator<Item = AlleleFreq>>(
     allele_frequencies: F,
 ) -> Result<Estimate> {

--- a/src/estimation/mutational_burden.rs
+++ b/src/estimation/mutational_burden.rs
@@ -158,7 +158,7 @@ pub(crate) fn collect_estimates(
         let vartypes = signatures(&rec);
 
         // push into MB function
-        for (sample_name, _) in &sample_ids {
+        for sample_name in sample_ids.keys() {
             for i in 0..alt_allele_count {
                 // if all alt_alleles are NaN, the list will only contain one NaN, so check for size
                 if i == vafmap.get(sample_name).unwrap().len()
@@ -343,12 +343,24 @@ pub(crate) fn collect_estimates(
     Eq,
 )]
 pub(crate) enum Vartype {
-    DEL,
-    INS,
-    INV,
-    DUP,
-    BND,
-    MNV,
+    #[strum(serialize = "DEL")]
+    #[serde(rename = "DEL")]
+    Del,
+    #[strum(serialize = "INS")]
+    #[serde(rename = "INS")]
+    Ins,
+    #[strum(serialize = "INV")]
+    #[serde(rename = "INV")]
+    Inv,
+    #[strum(serialize = "DUP")]
+    #[serde(rename = "DUP")]
+    Dup,
+    #[strum(serialize = "BND")]
+    #[serde(rename = "BND")]
+    Bnd,
+    #[strum(serialize = "MNV")]
+    #[serde(rename = "MNV")]
+    Mnv,
     Complex,
     #[strum(serialize = "A>C")]
     #[serde(rename = "A>C")]
@@ -403,12 +415,24 @@ pub(crate) enum Vartype {
     Eq,
 )]
 pub(crate) enum Signature {
-    DEL,
-    INS,
-    INV,
-    DUP,
-    BND,
-    MNV,
+    #[strum(serialize = "DEL")]
+    #[serde(rename = "DEL")]
+    Del,
+    #[strum(serialize = "INS")]
+    #[serde(rename = "INS")]
+    Ins,
+    #[strum(serialize = "INV")]
+    #[serde(rename = "INV")]
+    Inv,
+    #[strum(serialize = "DUP")]
+    #[serde(rename = "DUP")]
+    Dup,
+    #[strum(serialize = "BND")]
+    #[serde(rename = "BND")]
+    Bnd,
+    #[strum(serialize = "MNV")]
+    #[serde(rename = "MNV")]
+    Mnv,
     Complex,
     #[strum(serialize = "C>A", serialize = "G>T")]
     #[serde(rename = "C>A")]
@@ -436,13 +460,13 @@ pub(crate) fn signatures(record: &bcf::Record) -> Vec<Signature> {
         .iter()
         .map(|alt_allele| {
             if alt_allele == b"<DEL>" {
-                Signature::DEL
+                Signature::Del
             } else if alt_allele == b"<INV>" {
-                Signature::INV
+                Signature::Inv
             } else if alt_allele == b"<DUP>" {
-                Signature::DUP
+                Signature::Dup
             } else if alt_allele == b"<BND>" {
-                Signature::BND
+                Signature::Bnd
             } else if ref_allele.len() == 1 && alt_allele.len() == 1 {
                 Signature::from_str(&format!(
                     "{}>{}",
@@ -451,11 +475,11 @@ pub(crate) fn signatures(record: &bcf::Record) -> Vec<Signature> {
                 ))
                 .unwrap()
             } else if ref_allele.len() > 1 && alt_allele.len() == 1 {
-                Signature::DEL
+                Signature::Del
             } else if ref_allele.len() == 1 && alt_allele.len() > 1 {
-                Signature::INS
+                Signature::Ins
             } else if ref_allele.len() == alt_allele.len() && ref_allele.len() > 1 {
-                Signature::MNV
+                Signature::Mnv
             } else {
                 Signature::Complex
             }
@@ -470,13 +494,13 @@ pub(crate) fn vartypes(record: &bcf::Record) -> Vec<Vartype> {
         .iter()
         .map(|alt_allele| {
             if alt_allele == b"<DEL>" {
-                Vartype::DEL
+                Vartype::Del
             } else if alt_allele == b"<INV>" {
-                Vartype::INV
+                Vartype::Inv
             } else if alt_allele == b"<DUP>" {
-                Vartype::DUP
+                Vartype::Dup
             } else if alt_allele == b"<BND>" {
-                Vartype::BND
+                Vartype::Bnd
             } else if ref_allele.len() == 1 && alt_allele.len() == 1 {
                 Vartype::from_str(&format!(
                     "{}>{}",
@@ -485,11 +509,11 @@ pub(crate) fn vartypes(record: &bcf::Record) -> Vec<Vartype> {
                 ))
                 .unwrap()
             } else if ref_allele.len() > 1 && alt_allele.len() == 1 {
-                Vartype::DEL
+                Vartype::Del
             } else if ref_allele.len() == 1 && alt_allele.len() > 1 {
-                Vartype::INS
+                Vartype::Ins
             } else if ref_allele.len() == alt_allele.len() && ref_allele.len() > 1 {
-                Vartype::MNV
+                Vartype::Mnv
             } else {
                 Vartype::Complex
             }

--- a/src/estimation/mutational_burden.rs
+++ b/src/estimation/mutational_burden.rs
@@ -463,6 +463,7 @@ pub(crate) fn signatures(record: &bcf::Record) -> Vec<Signature> {
         .collect_vec()
 }
 
+#[allow(dead_code)]
 pub(crate) fn vartypes(record: &bcf::Record) -> Vec<Vartype> {
     let ref_allele = record.alleles()[0];
     record.alleles()[1..]

--- a/src/grammar/mod.rs
+++ b/src/grammar/mod.rs
@@ -404,7 +404,7 @@ impl VariantTypeFraction {
             VariantType::Insertion(_) | VariantType::Deletion(_) | VariantType::Replacement => {
                 self.indel
             }
-            VariantType::MNV => self.mnv,
+            VariantType::Mnv => self.mnv,
             VariantType::Inversion | VariantType::Breakend | VariantType::Duplication => self.sv,
             _ => 1.0,
         }

--- a/src/grammar/vaftree.rs
+++ b/src/grammar/vaftree.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use itertools::Itertools;
 
 use crate::errors;
-use crate::grammar::{formula::NormalizedFormula, formula::IUPAC, Scenario, VAFSpectrum};
+use crate::grammar::{formula::Iupac, formula::NormalizedFormula, Scenario, VAFSpectrum};
 use crate::variants::model::AlleleFreq;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -43,15 +43,15 @@ impl<'a> IntoIterator for &'a VAFTree {
     type IntoIter = std::slice::Iter<'a, Node>;
 
     fn into_iter(self) -> Self::IntoIter {
-        (&self.inner).into_iter()
+        (&self.inner).iter()
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) enum NodeKind {
     Variant {
-        refbase: IUPAC,
-        altbase: IUPAC,
+        refbase: Iupac,
+        altbase: Iupac,
         positive: bool,
     },
     Sample {
@@ -70,7 +70,7 @@ pub(crate) struct Node {
 }
 
 impl Node {
-    pub(crate) fn leafs<'a>(&'a mut self) -> Vec<&'a mut Node> {
+    pub(crate) fn leafs(&mut self) -> Vec<&mut Node> {
         fn collect_leafs<'a>(node: &'a mut Node, leafs: &mut Vec<&'a mut Node>) {
             if node.children.is_empty() {
                 leafs.push(node);
@@ -132,7 +132,7 @@ impl VAFTree {
                             _ => 0,
                         })
                         .collect_vec();
-                    let mut roots = from(&operands[0], scenario)?;
+                    let mut roots = from(operands[0], scenario)?;
                     for operand in &operands[1..] {
                         let subtrees = from(operand, scenario)?;
                         for subtree in &mut roots {

--- a/src/testcase.rs
+++ b/src/testcase.rs
@@ -280,8 +280,8 @@ impl Testcase {
             (Variant::Insertion(ref seq), _) => {
                 (pos.saturating_sub(1000), pos + seq.len() as u64 + 1000)
             }
-            (Variant::SNV(_), _) => (pos.saturating_sub(100), pos + 1 + 100),
-            (Variant::MNV(ref bases), _) => {
+            (Variant::Snv(_), _) => (pos.saturating_sub(100), pos + 1 + 100),
+            (Variant::Mnv(ref bases), _) => {
                 (pos.saturating_sub(100), pos + bases.len() as u64 + 100)
             }
             (Variant::Breakend { .. }, _) => {

--- a/src/testcase.rs
+++ b/src/testcase.rs
@@ -194,9 +194,7 @@ impl Testcase {
 
                 for rec in &mut found {
                     if utils::is_bnd(rec)? {
-                        if let Some(event) =
-                            utils::info_tag_event(rec)?.map(|event| event.to_owned())
-                        {
+                        if let Some(event) = utils::info_tag_event(rec)? {
                             // METHOD: for breakend events, collect all the other breakends.
                             if breakend_index.is_none() {
                                 breakend_index = Some(BreakendIndex::new(&self.candidates)?);
@@ -323,7 +321,7 @@ impl Testcase {
             let mut header = bam::header::Header::new();
             header.push_record(
                 bam::header::HeaderRecord::new(b"SQ")
-                    .push_tag(b"SN", &str::from_utf8(&chrom_name)?)
+                    .push_tag(b"SN", &str::from_utf8(chrom_name)?)
                     .push_tag(b"LN", &format!("{}", ref_end - ref_start)),
             );
 
@@ -387,7 +385,7 @@ impl Testcase {
         };
 
         // fetch reference
-        let ref_name = str::from_utf8(&chrom_name)?;
+        let ref_name = str::from_utf8(chrom_name)?;
 
         // limit ref_end
         for seq in self.reference_reader.index.sequences() {

--- a/src/utils/anonymize.rs
+++ b/src/utils/anonymize.rs
@@ -15,7 +15,7 @@ impl Anonymizer {
         let mut alphabet = b"ACGT".to_owned();
         alphabet.shuffle(&mut thread_rng());
         let mut replacements = HashMap::new();
-        for (base, repl) in b"ACGT".into_iter().zip(&alphabet) {
+        for (base, repl) in b"ACGT".iter().zip(&alphabet) {
             replacements.insert(*base, *repl);
         }
         replacements.insert(b'N', b'N');

--- a/src/utils/collect_variants.rs
+++ b/src/utils/collect_variants.rs
@@ -196,10 +196,10 @@ pub(crate) fn collect_variants(
                 // skip any other special alleles
             } else if alt_allele.len() == 1 && ref_allele.len() == 1 {
                 // SNV
-                variants.push(model::Variant::SNV(alt_allele[0]));
+                variants.push(model::Variant::Snv(alt_allele[0]));
             } else if alt_allele.len() == ref_allele.len() {
                 // MNV
-                variants.push(model::Variant::MNV(alt_allele.to_vec()));
+                variants.push(model::Variant::Mnv(alt_allele.to_vec()));
             } else {
                 // TODO fix position if variant is like this: cttt -> ct
                 if is_valid_deletion_alleles(ref_allele, alt_allele) {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -87,10 +87,7 @@ pub(crate) fn contains_indel_op(record: &bam::Record) -> bool {
         .cigar_cached()
         .expect("bug: cigar accessed before caching")
         .iter()
-        .any(|op| match op {
-            Cigar::Ins(_) | Cigar::Del(_) => true,
-            _ => false,
-        })
+        .any(|op| matches!(op, Cigar::Ins(_) | Cigar::Del(_)))
 }
 
 #[derive(new, Getters, CopyGetters, Debug)]
@@ -231,10 +228,11 @@ where
             }
         }
 
-        for p in tags_prob_sum(&mut record, &tags, vartype)? {
-            if let Some(p) = p {
-                prob_dist.push(NotNan::new(*p)?);
-            }
+        for p in (tags_prob_sum(&mut record, &tags, vartype)?)
+            .into_iter()
+            .flatten()
+        {
+            prob_dist.push(NotNan::new(*p)?);
         }
     }
     prob_dist.sort();
@@ -264,12 +262,7 @@ pub(crate) fn filter_by_threshold<E: Event>(
 
     let tags = events.iter().map(|e| e.tag_name("PROB")).collect_vec();
     let filter = |record: &mut bcf::Record| -> Result<Vec<bool>> {
-        let bnd_event = if let Ok(event) = info_tag_event(record) {
-            event.map(|event| event.to_owned())
-        } else {
-            None
-        };
-
+        let bnd_event = info_tag_event(record).ok().flatten();
         let keep = if let Some(event) = bnd_event.as_ref() {
             breakend_event_decisions.get(event).cloned()
         } else {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -443,7 +443,7 @@ mod tests {
             String::from("PROB_ERR_REF"),
         ];
 
-        let snv = VariantType::SNV;
+        let snv = VariantType::Snv;
 
         if let Ok(prob_sum) = tags_prob_sum(&mut record, &alt_tags, Some(&snv)) {
             assert_eq!(LogProb::ln_one(), prob_sum[0].unwrap());

--- a/src/variants/evidence/insert_size.rs
+++ b/src/variants/evidence/insert_size.rs
@@ -27,8 +27,8 @@ pub(crate) fn estimate_insert_size(left: &bam::Record, right: &bam::Record) -> R
         ))
     };
 
-    let (left_start, left_end) = aln(left, &left_cigar)?;
-    let (right_start, right_end) = aln(right, &right_cigar)?;
+    let (left_start, left_end) = aln(left, left_cigar)?;
+    let (right_start, right_end) = aln(right, right_cigar)?;
     // as defined by Torsten Seemann
     // (http://thegenomefactory.blogspot.nl/2013/08/paired-end-read-confusion-library.html)
     let inner_mate_distance = right_start as i64 - left_end as i64;

--- a/src/variants/evidence/observation.rs
+++ b/src/variants/evidence/observation.rs
@@ -107,7 +107,6 @@ impl ops::BitOrAssign for Strand {
             *self = rhs;
         } else if let Strand::None = rhs {
             // no new information
-            return;
         } else if *self != rhs {
             *self = Strand::Both;
         }

--- a/src/variants/evidence/realignment/mod.rs
+++ b/src/variants/evidence/realignment/mod.rs
@@ -426,7 +426,7 @@ impl Realigner for PairHMMRealigner {
     {
         // METHOD: We shrink the area to run the HMM against to an environment around the best
         // edit distance hits.
-        allele_params.shrink_to_hit(&hit);
+        allele_params.shrink_to_hit(hit);
 
         // METHOD: Further, we run the HMM on a band around the best edit distance.
         self.pairhmm.prob_related(

--- a/src/variants/model/bias/read_position_bias.rs
+++ b/src/variants/model/bias/read_position_bias.rs
@@ -17,12 +17,11 @@ impl Default for ReadPositionBias {
 
 impl Bias for ReadPositionBias {
     fn prob(&self, observation: &Observation<ReadPosition>) -> LogProb {
-        let p = match (self, observation.read_position) {
+        match (self, observation.read_position) {
             (ReadPositionBias::None, _) => observation.prob_hit_base, // normal
             (ReadPositionBias::Some, ReadPosition::Major) => LogProb::ln_one(), // bias
             (ReadPositionBias::Some, ReadPosition::Some) => LogProb::ln_zero(), // no bias
-        };
-        p
+        }
     }
 
     fn prob_any(&self, observation: &Observation<ReadPosition>) -> LogProb {

--- a/src/variants/model/mod.rs
+++ b/src/variants/model/mod.rs
@@ -151,9 +151,9 @@ pub enum VariantType {
     #[strum(serialize = "DEL")]
     Deletion(Option<Range<u64>>),
     #[strum(serialize = "SNV")]
-    SNV,
+    Snv,
     #[strum(serialize = "MNV")]
-    MNV,
+    Mnv,
     #[strum(serialize = "BND")]
     Breakend,
     #[strum(serialize = "INV")]
@@ -171,7 +171,7 @@ impl From<&str> for VariantType {
         match string {
             "INS" => VariantType::Insertion(None),
             "DEL" => VariantType::Deletion(None),
-            "SNV" => VariantType::SNV,
+            "SNV" => VariantType::Snv,
             "REF" => VariantType::None,
             "INV" => VariantType::Inversion,
             "DUP" => VariantType::Duplication,
@@ -186,8 +186,8 @@ impl From<&str> for VariantType {
 pub(crate) enum Variant {
     Deletion(u64),
     Insertion(Vec<u8>),
-    SNV(u8),
-    MNV(Vec<u8>),
+    Snv(u8),
+    Mnv(Vec<u8>),
     Breakend {
         ref_allele: Vec<u8>,
         spec: Vec<u8>,
@@ -217,8 +217,8 @@ impl Variant {
             }
             (&Variant::Deletion(_), &VariantType::Deletion(None)) => true,
             (&Variant::Insertion(_), &VariantType::Insertion(None)) => true,
-            (&Variant::SNV(_), &VariantType::SNV) => true,
-            (&Variant::MNV(_), &VariantType::MNV) => true,
+            (&Variant::Snv(_), &VariantType::Snv) => true,
+            (&Variant::Mnv(_), &VariantType::Mnv) => true,
             (&Variant::None, &VariantType::None) => true,
             (&Variant::Breakend { .. }, &VariantType::Breakend) => true,
             (&Variant::Inversion { .. }, &VariantType::Inversion) => true,
@@ -232,8 +232,8 @@ impl Variant {
         match self {
             Variant::Deletion(_) => VariantType::Deletion(None),
             Variant::Insertion(_) => VariantType::Insertion(None),
-            Variant::SNV(_) => VariantType::SNV,
-            Variant::MNV(_) => VariantType::MNV,
+            Variant::Snv(_) => VariantType::Snv,
+            Variant::Mnv(_) => VariantType::Mnv,
             Variant::Breakend { .. } => VariantType::Breakend,
             Variant::Inversion(_) => VariantType::Inversion,
             Variant::Duplication(_) => VariantType::Duplication,
@@ -246,8 +246,8 @@ impl Variant {
         match *self {
             Variant::Deletion(l) => l,
             Variant::Insertion(ref s) => s.len() as u64,
-            Variant::SNV(_) => 1,
-            Variant::MNV(ref alt) => alt.len() as u64,
+            Variant::Snv(_) => 1,
+            Variant::Mnv(ref alt) => alt.len() as u64,
             Variant::Breakend { .. } => 1,
             Variant::Inversion(l) => l,
             Variant::Duplication(l) => l,

--- a/src/variants/model/modes/generic.rs
+++ b/src/variants/model/modes/generic.rs
@@ -14,7 +14,7 @@ use crate::variants::model::{bias::Biases, AlleleFreq, Contamination, VariantTyp
 use crate::variants::sample::Pileup;
 
 #[derive(new, Clone, Debug)]
-pub(crate) struct SNV {
+pub(crate) struct Snv {
     refbase: u8,
     altbase: u8,
 }
@@ -23,7 +23,7 @@ pub(crate) struct SNV {
 #[get = "pub"]
 pub(crate) struct Data {
     pileups: Vec<Pileup>,
-    snv: Option<SNV>,
+    snv: Option<Snv>,
 }
 
 impl Data {
@@ -213,7 +213,7 @@ impl GenericPosterior {
                 refbase: given_refbase,
                 altbase: given_altbase,
             } => {
-                if let Some(SNV { refbase, altbase }) = data.snv {
+                if let Some(Snv { refbase, altbase }) = data.snv {
                     let contains =
                         given_refbase.contains(refbase) && given_altbase.contains(altbase);
                     if (*positive && !contains) || (!*positive && contains) {
@@ -260,7 +260,7 @@ impl Posterior for GenericPosterior {
                 && bias.is_informative(&data.pileups)
                 && bias.is_likely(&data.pileups)
         });
-        let p = LogProb::ln_sum_exp(
+        LogProb::ln_sum_exp(
             &possible_biases
                 .cartesian_product(vaf_tree)
                 .map(|(biases, node)| {
@@ -276,9 +276,7 @@ impl Posterior for GenericPosterior {
                         )
                 })
                 .collect_vec(),
-        );
-
-        p
+        )
     }
 }
 

--- a/src/variants/model/modes/tumor.rs
+++ b/src/variants/model/modes/tumor.rs
@@ -9,9 +9,9 @@ pub(crate) struct TumorNormalPair<T> {
     pub(crate) normal: T,
 }
 
-impl<T> Into<Vec<T>> for TumorNormalPair<T> {
-    fn into(self) -> Vec<T> {
-        vec![self.tumor, self.normal]
+impl<T> From<TumorNormalPair<T>> for Vec<T> {
+    fn from(tnp: TumorNormalPair<T>) -> Self {
+        vec![tnp.tumor, tnp.normal]
     }
 }
 

--- a/src/variants/sample.rs
+++ b/src/variants/sample.rs
@@ -168,11 +168,11 @@ pub(crate) fn estimate_alignment_properties<P: AsRef<Path>>(
     allow_hardclips: bool,
 ) -> Result<alignment_properties::AlignmentProperties> {
     let mut bam = bam::Reader::from_path(path)?;
-    Ok(alignment_properties::AlignmentProperties::estimate(
+    alignment_properties::AlignmentProperties::estimate(
         &mut bam,
         omit_insert_size,
         allow_hardclips,
-    )?)
+    )
 }
 
 /// A sequenced sample, e.g., a tumor or a normal sample.

--- a/src/variants/sample.rs
+++ b/src/variants/sample.rs
@@ -168,11 +168,7 @@ pub(crate) fn estimate_alignment_properties<P: AsRef<Path>>(
     allow_hardclips: bool,
 ) -> Result<alignment_properties::AlignmentProperties> {
     let mut bam = bam::Reader::from_path(path)?;
-    alignment_properties::AlignmentProperties::estimate(
-        &mut bam,
-        omit_insert_size,
-        allow_hardclips,
-    )
+    alignment_properties::AlignmentProperties::estimate(&mut bam, omit_insert_size, allow_hardclips)
 }
 
 /// A sequenced sample, e.g., a tumor or a normal sample.

--- a/src/variants/types/breakends.rs
+++ b/src/variants/types/breakends.rs
@@ -376,11 +376,7 @@ impl<R: Realigner> SamplingBias for BreakendGroup<R> {
                 return Some(read_len);
             }
         }
-        if let Some(maxfrac) = alignment_properties.frac_max_softclip {
-            Some((read_len as f64 * maxfrac) as u64)
-        } else {
-            None
-        }
+        alignment_properties.frac_max_softclip.map(|maxfrac| (read_len as f64 * maxfrac) as u64)
     }
 
     fn enclosable_len(&self) -> Option<u64> {

--- a/src/variants/types/breakends.rs
+++ b/src/variants/types/breakends.rs
@@ -376,7 +376,9 @@ impl<R: Realigner> SamplingBias for BreakendGroup<R> {
                 return Some(read_len);
             }
         }
-        alignment_properties.frac_max_softclip.map(|maxfrac| (read_len as f64 * maxfrac) as u64)
+        alignment_properties
+            .frac_max_softclip
+            .map(|maxfrac| (read_len as f64 * maxfrac) as u64)
     }
 
     fn enclosable_len(&self) -> Option<u64> {

--- a/src/variants/types/deletion.rs
+++ b/src/variants/types/deletion.rs
@@ -113,7 +113,9 @@ impl<R: Realigner> SamplingBias for Deletion<R> {
                 }
             }
         }
-        alignment_properties.frac_max_softclip.map(|maxfrac| (read_len as f64 * maxfrac) as u64)
+        alignment_properties
+            .frac_max_softclip
+            .map(|maxfrac| (read_len as f64 * maxfrac) as u64)
     }
 
     fn enclosable_len(&self) -> Option<u64> {
@@ -183,14 +185,12 @@ impl<R: Realigner> Variant for Deletion<R> {
                     } else {
                         None
                     }
+                } else if !self.locus.overlap(left, true).is_none()
+                    || !self.locus.overlap(right, true).is_none()
+                {
+                    Some(vec![0])
                 } else {
-                    if !self.locus.overlap(left, true).is_none()
-                        || !self.locus.overlap(right, true).is_none()
-                    {
-                        Some(vec![0])
-                    } else {
-                        None
-                    }
+                    None
                 }
             }
         }

--- a/src/variants/types/deletion.rs
+++ b/src/variants/types/deletion.rs
@@ -113,11 +113,7 @@ impl<R: Realigner> SamplingBias for Deletion<R> {
                 }
             }
         }
-        if let Some(maxfrac) = alignment_properties.frac_max_softclip {
-            Some((read_len as f64 * maxfrac) as u64)
-        } else {
-            None
-        }
+        alignment_properties.frac_max_softclip.map(|maxfrac| (read_len as f64 * maxfrac) as u64)
     }
 
     fn enclosable_len(&self) -> Option<u64> {

--- a/src/variants/types/insertion.rs
+++ b/src/variants/types/insertion.rs
@@ -86,11 +86,7 @@ impl<R: Realigner> SamplingBias for Insertion<R> {
                 }
             }
         }
-        if let Some(maxfrac) = alignment_properties.frac_max_softclip {
-            Some((read_len as f64 * maxfrac) as u64)
-        } else {
-            None
-        }
+        alignment_properties.frac_max_softclip.map(|maxfrac| (read_len as f64 * maxfrac) as u64)
     }
 
     fn enclosable_len(&self) -> Option<u64> {

--- a/src/variants/types/insertion.rs
+++ b/src/variants/types/insertion.rs
@@ -86,7 +86,9 @@ impl<R: Realigner> SamplingBias for Insertion<R> {
                 }
             }
         }
-        alignment_properties.frac_max_softclip.map(|maxfrac| (read_len as f64 * maxfrac) as u64)
+        alignment_properties
+            .frac_max_softclip
+            .map(|maxfrac| (read_len as f64 * maxfrac) as u64)
     }
 
     fn enclosable_len(&self) -> Option<u64> {

--- a/src/variants/types/mnv.rs
+++ b/src/variants/types/mnv.rs
@@ -26,21 +26,21 @@ use crate::variants::types::{
 };
 use crate::{default_emission, default_ref_base_emission};
 
-pub(crate) struct MNV<R: Realigner> {
+pub(crate) struct Mnv<R: Realigner> {
     locus: SingleLocus,
     ref_bases: Vec<u8>,
     alt_bases: Rc<Vec<u8>>,
     realigner: RefCell<R>,
 }
 
-impl<R: Realigner> MNV<R> {
+impl<R: Realigner> Mnv<R> {
     pub(crate) fn new<L: genome::AbstractLocus>(
         locus: L,
         ref_bases: Vec<u8>,
         alt_bases: Vec<u8>,
         realigner: R,
     ) -> Self {
-        MNV {
+        Mnv {
             locus: SingleLocus::new(genome::Interval::new(
                 locus.contig().to_owned(),
                 locus.pos()..locus.pos() + alt_bases.len() as u64,
@@ -52,8 +52,8 @@ impl<R: Realigner> MNV<R> {
     }
 }
 
-impl<'a, R: Realigner> Realignable<'a> for MNV<R> {
-    type EmissionParams = MNVEmissionParams<'a>;
+impl<'a, R: Realigner> Realignable<'a> for Mnv<R> {
+    type EmissionParams = MnvEmissionParams<'a>;
 
     fn alt_emission_params(
         &self,
@@ -61,13 +61,13 @@ impl<'a, R: Realigner> Realignable<'a> for MNV<R> {
         ref_buffer: Arc<reference::Buffer>,
         _: &genome::Interval,
         ref_window: usize,
-    ) -> Result<Vec<MNVEmissionParams<'a>>> {
+    ) -> Result<Vec<MnvEmissionParams<'a>>> {
         let start = self.locus.range().start as usize;
 
         let ref_seq = ref_buffer.seq(self.locus.contig())?;
 
         let ref_seq_len = ref_seq.len();
-        Ok(vec![MNVEmissionParams {
+        Ok(vec![MnvEmissionParams {
             ref_seq,
             ref_offset: start.saturating_sub(ref_window),
             ref_end: cmp::min(start + self.alt_bases.len() + ref_window, ref_seq_len),
@@ -79,7 +79,7 @@ impl<'a, R: Realigner> Realignable<'a> for MNV<R> {
     }
 }
 
-impl<R: Realigner> Variant for MNV<R> {
+impl<R: Realigner> Variant for Mnv<R> {
     type Evidence = SingleEndEvidence;
     type Loci = SingleLocus;
 
@@ -202,7 +202,7 @@ impl<R: Realigner> Variant for MNV<R> {
 }
 
 /// Emission parameters for PairHMM over insertion allele.
-pub(crate) struct MNVEmissionParams<'a> {
+pub(crate) struct MnvEmissionParams<'a> {
     ref_seq: Arc<Vec<u8>>,
     ref_offset: usize,
     ref_end: usize,
@@ -212,7 +212,7 @@ pub(crate) struct MNVEmissionParams<'a> {
     read_emission: Rc<ReadEmission<'a>>,
 }
 
-impl<'a> RefBaseEmission for MNVEmissionParams<'a> {
+impl<'a> RefBaseEmission for MnvEmissionParams<'a> {
     #[inline]
     fn ref_base(&self, i: usize) -> u8 {
         let i_ = i + self.ref_offset;
@@ -227,7 +227,7 @@ impl<'a> RefBaseEmission for MNVEmissionParams<'a> {
     default_ref_base_emission!();
 }
 
-impl<'a> EmissionParameters for MNVEmissionParams<'a> {
+impl<'a> EmissionParameters for MnvEmissionParams<'a> {
     default_emission!();
 
     #[inline]

--- a/src/variants/types/mod.rs
+++ b/src/variants/types/mod.rs
@@ -32,10 +32,10 @@ pub(crate) use deletion::Deletion;
 pub(crate) use duplication::Duplication;
 pub(crate) use insertion::Insertion;
 pub(crate) use inversion::Inversion;
-pub(crate) use mnv::MNV;
+pub(crate) use mnv::Mnv;
 pub(crate) use none::None;
 pub(crate) use replacement::Replacement;
-pub(crate) use snv::SNV;
+pub(crate) use snv::Snv;
 
 #[derive(Debug, CopyGetters, Builder)]
 #[getset(get_copy = "pub")]

--- a/src/variants/types/replacement.rs
+++ b/src/variants/types/replacement.rs
@@ -53,7 +53,7 @@ impl<R: Realigner> Replacement<R> {
         // If replacement ends at the end of the contig, we do not need a right breakend.
         if interval.range().end < chrom_seq.len() as u64 {
             let ref_allele = get_ref_allele(interval.range().end);
-            let mut replacement = replacement.clone();
+            let mut replacement = replacement;
             replacement.push(ref_allele[0]);
             breakend_group_builder.push_breakend(Breakend::from_operations(
                 get_locus(interval.range().end),

--- a/src/variants/types/snv.rs
+++ b/src/variants/types/snv.rs
@@ -177,7 +177,7 @@ impl<'a> RefBaseEmission for SnvEmissionParams<'a> {
     fn ref_base(&self, i: usize) -> u8 {
         let i_ = i + self.ref_offset;
 
-        if i_ < self.alt_start || i_ >= self.alt_start + 1 {
+        if i_ != self.alt_start {
             self.ref_seq[i_]
         } else {
             self.alt_base

--- a/src/variants/types/snv.rs
+++ b/src/variants/types/snv.rs
@@ -25,16 +25,16 @@ use crate::variants::types::{
 };
 use crate::{default_emission, default_ref_base_emission};
 
-pub(crate) struct SNV<R: Realigner> {
+pub(crate) struct Snv<R: Realigner> {
     locus: SingleLocus,
     ref_base: u8,
     alt_base: u8,
     realigner: RefCell<R>,
 }
 
-impl<R: Realigner> SNV<R> {
+impl<R: Realigner> Snv<R> {
     pub(crate) fn new(locus: genome::Locus, ref_base: u8, alt_base: u8, realigner: R) -> Self {
-        SNV {
+        Snv {
             locus: SingleLocus::new(genome::Interval::new(
                 locus.contig().to_owned(),
                 locus.pos()..locus.pos() + 1,
@@ -46,8 +46,8 @@ impl<R: Realigner> SNV<R> {
     }
 }
 
-impl<'a, R: Realigner> Realignable<'a> for SNV<R> {
-    type EmissionParams = SNVEmissionParams<'a>;
+impl<'a, R: Realigner> Realignable<'a> for Snv<R> {
+    type EmissionParams = SnvEmissionParams<'a>;
 
     fn alt_emission_params(
         &self,
@@ -55,13 +55,13 @@ impl<'a, R: Realigner> Realignable<'a> for SNV<R> {
         ref_buffer: Arc<reference::Buffer>,
         _: &genome::Interval,
         ref_window: usize,
-    ) -> Result<Vec<SNVEmissionParams<'a>>> {
+    ) -> Result<Vec<SnvEmissionParams<'a>>> {
         let start = self.locus.range().start as usize;
 
         let ref_seq = ref_buffer.seq(self.locus.contig())?;
 
         let ref_seq_len = ref_seq.len();
-        Ok(vec![SNVEmissionParams {
+        Ok(vec![SnvEmissionParams {
             ref_seq,
             ref_offset: start.saturating_sub(ref_window),
             ref_end: cmp::min(start + 1 + ref_window, ref_seq_len),
@@ -72,7 +72,7 @@ impl<'a, R: Realigner> Realignable<'a> for SNV<R> {
     }
 }
 
-impl<R: Realigner> Variant for SNV<R> {
+impl<R: Realigner> Variant for Snv<R> {
     type Evidence = SingleEndEvidence;
     type Loci = SingleLocus;
 
@@ -165,7 +165,7 @@ impl<R: Realigner> Variant for SNV<R> {
 }
 
 /// Emission parameters for PairHMM over insertion allele.
-pub(crate) struct SNVEmissionParams<'a> {
+pub(crate) struct SnvEmissionParams<'a> {
     ref_seq: Arc<Vec<u8>>,
     ref_offset: usize,
     ref_end: usize,
@@ -174,7 +174,7 @@ pub(crate) struct SNVEmissionParams<'a> {
     read_emission: Rc<ReadEmission<'a>>,
 }
 
-impl<'a> RefBaseEmission for SNVEmissionParams<'a> {
+impl<'a> RefBaseEmission for SnvEmissionParams<'a> {
     #[inline]
     fn ref_base(&self, i: usize) -> u8 {
         let i_ = i + self.ref_offset;
@@ -189,7 +189,7 @@ impl<'a> RefBaseEmission for SNVEmissionParams<'a> {
     default_ref_base_emission!();
 }
 
-impl<'a> EmissionParameters for SNVEmissionParams<'a> {
+impl<'a> EmissionParameters for SnvEmissionParams<'a> {
     default_emission!();
 
     #[inline]


### PR DESCRIPTION
### Description

This PR addresses some clippy lints, but notably does not fix the floating point comparison ones, since these are exact checks for 1.0 mostly. Perhaps one could check the floating point bits instead?

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
