### PR TITLE
fix: testcase 71 sometimes fails because formula normalization via BDD is not deterministic

### DIFF
--- a/src/grammar/formula.rs
+++ b/src/grammar/formula.rs
@@ -44,7 +44,7 @@ impl IUPAC {
 #[grammar = "grammar/formula.pest"]
 pub(crate) struct FormulaParser;
 
-#[derive(PartialEq, Eq, Clone, Debug, Hash)]
+#[derive(PartialEq, Eq, Clone, Debug, Hash, PartialOrd, Ord)]
 pub(crate) enum Formula {
     Conjunction { operands: Vec<Formula> },
     Disjunction { operands: Vec<Formula> },
@@ -81,7 +81,7 @@ impl From<NormalizedFormula> for Formula {
     }
 }
 
-#[derive(PartialEq, Eq, Clone, Debug, Hash)]
+#[derive(PartialEq, Eq, Clone, Debug, Hash, PartialOrd, Ord)]
 pub(crate) enum FormulaTerminal {
     Atom {
         sample: String,
@@ -843,7 +843,7 @@ impl Formula {
     }
 }
 
-#[derive(PartialEq, Eq, Clone, Debug, Hash)]
+#[derive(PartialEq, Eq, Clone, Debug, Hash, PartialOrd, Ord)]
 pub(crate) enum NormalizedFormula {
     Conjunction {
         operands: Vec<NormalizedFormula>,
@@ -924,7 +924,7 @@ impl std::fmt::Display for NormalizedFormula {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub(crate) enum VAFSpectrum {
     Set(BTreeSet<AlleleFreq>),
     Range(VAFRange),

--- a/src/grammar/mod.rs
+++ b/src/grammar/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::convert::TryFrom;
 use std::fs::File;
 use std::io::Read;
@@ -241,12 +241,16 @@ impl Scenario {
             if e1 == e2 {
                 continue;
             }
-            // skip if one of the operands is a terminal `False`.
             let terms = [e1, e2]
                 .iter()
                 .filter(|e| !matches!(e.to_terminal(), Some(FormulaTerminal::False)))
                 .map(|&v| v.clone())
-                .collect();
+                .collect_vec();
+
+            // skip if any of the operands is a terminal `False`.
+            if terms.len() != 2 {
+                continue;
+            }
 
             let disjunction =
                 Formula::from(Formula::Disjunction { operands: terms }.normalize(self, contig)?);

--- a/src/grammar/mod.rs
+++ b/src/grammar/mod.rs
@@ -252,6 +252,7 @@ impl Scenario {
                 continue;
             }
 
+            // TODO make sure the disjunction really is canonical, such that trying to check if it's contained in `events` isn't a game of chance
             let disjunction =
                 Formula::from(Formula::Disjunction { operands: terms }.normalize(self, contig)?);
             if events.contains(&disjunction) {

--- a/src/grammar/mod.rs
+++ b/src/grammar/mod.rs
@@ -221,15 +221,10 @@ impl Scenario {
     }
 
     pub(crate) fn validate(&self, contig: &str) -> Result<()> {
-        let events = self
-            .events()
-            .iter()
-            .filter(|(name, _)| *name != "absent")
-            .map(|(_, formula)| formula.normalize(self, contig).map(Formula::from))
-            .collect::<Result<HashSet<_>>>()?;
         let names = self
             .events()
             .iter()
+            .filter(|(name, _)| *name != "absent")
             .map(|(name, formula)| {
                 (
                     // if `formula.normalize(…)` failed above, we won't get to this line,
@@ -240,6 +235,7 @@ impl Scenario {
             })
             .into_group_map();
         let mut overlapping = vec![];
+        let events: Vec<_> = names.keys().sorted().cloned().collect();
         for (e1, e2) in events.iter().tuple_combinations() {
             // skip comparison of event with itself
             if e1 == e2 {


### PR DESCRIPTION
### Description

testcase 71 sometimes fails because formula normalization via BDD is not deterministic.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
