### PR TITLE
fix: Removed check for coding variants

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1077,13 +1077,9 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
 
                 prior.plot(&sample, &sample_infos.names)?;
             }
-            PlotKind::Scatter {
-                sample_x,
-                sample_y,
-            } => estimation::sample_variants::vaf_scatter(
-                &sample_x,
-                &sample_y,
-            )?,
+            PlotKind::Scatter { sample_x, sample_y } => {
+                estimation::sample_variants::vaf_scatter(&sample_x, &sample_y)?
+            }
         },
     }
     Ok(())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -302,17 +302,11 @@ pub enum PlotKind {
     #[structopt(
         name = "scatter",
         about = "Plot variant allelic fraction scatter plot overlayed with a contour plot between two sample groups",
-        usage = "varlociraptor plot scatter --somatic-tumor-events SOMATIC_TUMOR \
-        --sample-x sample1 --sample-y sample2 sample3 < calls.bcf | vg2svg > scatter.svg",
+        usage = "varlociraptor plot scatter --sample-x sample1 \
+        --sample-y sample2 sample3 < calls.bcf | vg2svg > scatter.svg",
         setting = structopt::clap::AppSettings::ColoredHelp,
     )]
     Scatter {
-        #[structopt(
-            long = "somatic-tumor-events",
-            default_value = "SOMATIC_TUMOR",
-            help = "Events to consider (e.g. SOMATIC_TUMOR)."
-        )]
-        somatic_tumor_events: Vec<String>,
         #[structopt(
             long = "sample-x",
             help = "Name of the first sample in the given VCF/BCF."
@@ -1084,11 +1078,9 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
                 prior.plot(&sample, &sample_infos.names)?;
             }
             PlotKind::Scatter {
-                somatic_tumor_events,
                 sample_x,
                 sample_y,
             } => estimation::sample_variants::vaf_scatter(
-                &somatic_tumor_events,
                 &sample_x,
                 &sample_y,
             )?,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -303,7 +303,7 @@ pub enum PlotKind {
         name = "scatter",
         about = "Plot variant allelic fraction scatter plot overlayed with a contour plot between two sample groups",
         usage = "varlociraptor plot scatter --somatic-tumor-events SOMATIC_TUMOR \
-        --sample-y sample1 --sample-x sample2 sample3 < calls.bcf | vg2svg > scatter.svg",
+        --sample-x sample1 --sample-y sample2 sample3 < calls.bcf | vg2svg > scatter.svg",
         setting = structopt::clap::AppSettings::ColoredHelp,
     )]
     Scatter {

--- a/src/estimation/sample_variants.rs
+++ b/src/estimation/sample_variants.rs
@@ -15,10 +15,7 @@ struct Scattervaf {
     tumor_vaf: f64,
 }
 
-pub(crate) fn vaf_scatter(
-    sample_x: &str,
-    sample_y: &[String],
-) -> Result<()> {
+pub(crate) fn vaf_scatter(sample_x: &str, sample_y: &[String]) -> Result<()> {
     let mut bcf = bcf::Reader::from_stdin()?;
 
     let mut plot_data = Vec::new();

--- a/src/estimation/sample_variants.rs
+++ b/src/estimation/sample_variants.rs
@@ -43,7 +43,7 @@ pub(crate) fn vaf_scatter(
     }
 
     for record in bcf.records() {
-        let mut rec = record.unwrap();
+        let rec = record.unwrap();
         let contig = str::from_utf8(header.rid2name(rec.rid().unwrap()).unwrap())?;
         let vcfpos = rec.pos() + 1;
 
@@ -77,8 +77,8 @@ pub(crate) fn vaf_scatter(
             for (y, id_y) in &ids_y {
                 let y_vafs = rec.format(b"AF").float()?[*id_y].to_owned();
                 // if all alt_alleles are NaN, the list will only contain one NaN, so check for size
-                if (i == x_vafs.len() && x_vafs[0].is_nan())
-                    || (i == y_vafs.len() && y_vafs[0].is_nan())
+                if (i >= x_vafs.len() && x_vafs[0].is_nan())
+                    || (i >= y_vafs.len() && y_vafs[0].is_nan())
                 {
                     continue;
                 }
@@ -104,12 +104,12 @@ pub(crate) fn vaf_scatter(
     }
 
     let print_plot =
-        |data: serde_json::Value, ylabel: serde_json::Value, blueprint: &str| -> Result<()> {
+        |data: serde_json::Value, xlabel: serde_json::Value, blueprint: &str| -> Result<()> {
             let mut blueprint = serde_json::from_str(blueprint)?;
             if let Value::Object(ref mut blueprint) = blueprint {
                 blueprint["data"][0]["values"] = data;
-                //blueprint["axes"][0]["title"] = xlabel;
-                blueprint["axes"][1]["title"] = ylabel;
+                blueprint["axes"][0]["title"] = xlabel;
+                //blueprint["axes"][1]["title"] = ylabel;
                 // print to STDOUT
                 println!("{}", serde_json::to_string_pretty(blueprint)?);
                 Ok(())

--- a/templates/plots/vaf_scatter_contour.json
+++ b/templates/plots/vaf_scatter_contour.json
@@ -61,7 +61,7 @@
       "round": true,
       "nice": true,
       "zero": true,
-      "domain": {"data": "source", "field": "normal_vaf"},
+      "domain": [0, 1],
       "range": "width"
     },
     {
@@ -70,7 +70,7 @@
       "round": true,
       "nice": true,
       "zero": true,
-      "domain": {"data": "source", "field": "tumor_vaf"},
+      "domain": [0, 1],
       "range": "height"
     },
     {

--- a/templates/plots/vaf_scatter_contour.json
+++ b/templates/plots/vaf_scatter_contour.json
@@ -33,8 +33,8 @@
           "type": "kde2d",
           "groupby": ["sample"],
           "size": [{"signal": "width"}, {"signal": "height"}],
-          "x": {"expr": "scale('x', datum.tumor_vaf)"},
-          "y": {"expr": "scale('y', datum.normal_vaf)"},
+          "x": {"expr": "scale('x', datum.normal_vaf)"},
+          "y": {"expr": "scale('y', datum.tumor_vaf)"},
           "bandwidth": {"signal": "[bandwidth, bandwidth]"},
           "counts": {"signal": "counts"}
         }
@@ -61,7 +61,7 @@
       "round": true,
       "nice": true,
       "zero": true,
-      "domain": {"data": "source", "field": "tumor_vaf"},
+      "domain": {"data": "source", "field": "normal_vaf"},
       "range": "width"
     },
     {
@@ -70,7 +70,7 @@
       "round": true,
       "nice": true,
       "zero": true,
-      "domain": {"data": "source", "field": "normal_vaf"},
+      "domain": {"data": "source", "field": "tumor_vaf"},
       "range": "height"
     },
     {
@@ -112,8 +112,8 @@
       "from": {"data": "source"},
       "encode": {
         "update": {
-          "x": {"scale": "x", "field": "tumor_vaf"},
-          "y": {"scale": "y", "field": "normal_vaf"},
+          "x": {"scale": "x", "field": "normal_vaf"},
+          "y": {"scale": "y", "field": "tumor_vaf"},
           "size": {"value": 4},
           "fill": {"value": "#ccc"}
         }


### PR DESCRIPTION
### Description

This PR removes the check for coding variants in the variant scatter plots. Now, all variants coding and non-coding should be considered.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
