### PR TITLE
chore: Fix CI test

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -201,7 +201,7 @@ pub(crate) trait Testcase {
                 } => {
                     // prepare test bam
                     let test_bam = self.sample_bam(sample_name);
-                    bam::index::build(&test_bam, None, bam::index::Type::BAI, 1).unwrap();
+                    bam::index::build(&test_bam, None, bam::index::Type::Bai, 1).unwrap();
 
                     // prepare alignment properties
                     let props =


### PR DESCRIPTION
This just fixes the testing which went missing when updating to `rust-htslib 0.38`.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
