### PR TITLE
perf: various speed improvements for scenario evaluations

### DIFF
--- a/src/variants/evidence/observation.rs
+++ b/src/variants/evidence/observation.rs
@@ -299,10 +299,9 @@ impl<P: Clone> Observation<P> {
         self.prob_ref > self.prob_alt
     }
 
-    pub(crate) fn is_strong_ref_support(&self) -> bool {
-        self.is_uniquely_mapping()
-            && BayesFactor::new(self.prob_ref, self.prob_alt).evidence_kass_raftery()
-                >= KassRaftery::Strong
+    pub(crate) fn is_positive_ref_support(&self) -> bool {
+        BayesFactor::new(self.prob_ref, self.prob_alt).evidence_kass_raftery()
+            >= KassRaftery::Positive
     }
 
     pub(crate) fn is_alt_support(&self) -> bool {

--- a/src/variants/model/modes/generic.rs
+++ b/src/variants/model/modes/generic.rs
@@ -43,9 +43,9 @@ pub(crate) enum CacheEntry {
 impl CacheEntry {
     fn new(contaminated: bool) -> Self {
         if contaminated {
-            CacheEntry::ContaminatedSample(likelihood::ContaminatedSampleCache::default())
+            CacheEntry::ContaminatedSample(likelihood::ContaminatedSampleCache::new(10000))
         } else {
-            CacheEntry::SingleSample(likelihood::SingleSampleCache::default())
+            CacheEntry::SingleSample(likelihood::SingleSampleCache::new(10000))
         }
     }
 }


### PR DESCRIPTION
### Description

use lru cache for likelihoods, skip formula tree branches if all observations indicate absence of a variant

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
