### PR TITLE
perf: do not consider empty pileups for bias preprocessing

### DIFF
--- a/src/variants/model/bias/mod.rs
+++ b/src/variants/model/bias/mod.rs
@@ -72,6 +72,9 @@ pub(crate) trait Bias: Default + cmp::PartialEq + std::fmt::Debug {
                     // This can safe a lot of time and also avoids unexpected reporting
                     // of artifacts in ambiguous cases.
                     false
+                } else if pileup.is_empty() {
+                    // METHOD: no reads, no need to consider for biases, hence, skip with false
+                    false
                 } else {
                     // METHOD: not enough reads, rather consider all biases to be sure
                     true


### PR DESCRIPTION
### Description

This should speed up scenarios with missing samples by an order of magnitude.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
