### PR TITLE
chore: Add check for order of records in bcf

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -166,7 +166,7 @@ pub enum PreprocessKind {
             parse(from_os_str),
             long,
             required = true,
-            help = "VCF/BCF file to process (if omitted, read from STDIN)."
+            help = "sorted VCF/BCF file to process (if omitted, read from STDIN)."
         )]
         candidates: PathBuf,
         #[structopt(

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -62,4 +62,6 @@ pub(crate) enum Error {
     InvalidReadOrientationInfo { value: String },
     #[error("the following events are not disjunct: {expressions}")]
     OverlappingEvents { expressions: String },
+    #[error("the input VCF/BCF is not sorted")]
+    UnsortedVariantFile,
 }

--- a/src/variants/evidence/realignment/mod.rs
+++ b/src/variants/evidence/realignment/mod.rs
@@ -19,12 +19,12 @@ use bio_types::genome::AbstractInterval;
 use rust_htslib::bam;
 
 use crate::errors::Error;
-use crate::reference;
 use crate::utils;
 use crate::variants::evidence::observation::Strand;
 use crate::variants::evidence::realignment::edit_distance::EditDistanceCalculation;
 use crate::variants::evidence::realignment::pairhmm::{ReadEmission, ReferenceEmissionParams};
 use crate::variants::types::{AlleleSupport, AlleleSupportBuilder, SingleLocus};
+use crate::{errors, reference};
 
 pub(crate) mod edit_distance;
 pub(crate) mod pairhmm;
@@ -209,6 +209,9 @@ pub(crate) trait Realigner {
                 merged_regions.push(region);
             } else {
                 let last = merged_regions.last_mut().unwrap();
+                if last.ref_interval.start > region.ref_interval.start {
+                    return Err(errors::Error::UnsortedVariantFile.into());
+                }
                 if region.ref_interval.start <= last.ref_interval.end {
                     // They overlap, hence merge.
                     last.ref_interval = last.ref_interval.start..region.ref_interval.end;


### PR DESCRIPTION
### Description

This PR ensures that two consecutive regions in the candidate region merging step are actually in the correct order.
This also adds the word "sorted" to the cli help text in front of "VCF/BCF".

I'll leave this as a draft because there's not test for this, yet.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
