### PR TITLE
feat: Add subcommand to infer classical genotypes from Varlociraptor's AF field.

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -75,6 +75,7 @@ pub enum Varlociraptor {
     #[structopt(
         name = "decode-phred",
         about = "Decode PHRED-scaled values to human readable probabilities.",
+        usage = "varlociraptor decode-phred < in.bcf > out.bcf",
         setting = structopt::clap::AppSettings::ColoredHelp,
     )]
     DecodePHRED,
@@ -96,6 +97,13 @@ pub enum Varlociraptor {
         #[structopt(subcommand)]
         kind: PlotKind,
     },
+    #[structopt(
+        name = "genotype",
+        about = "Infer classical genotypes from Varlociraptor's AF field (1.0: 1/1, 0.5: 0/1, 0.0: 0/0, otherwise: 0/1). This assumes diploid samples.",
+        usage = "varlociraptor genotype < in.bcf > out.bcf",
+        setting = structopt::clap::AppSettings::ColoredHelp,
+    )]
+    Genotype,
 }
 
 pub struct PreprocessInput {
@@ -1038,6 +1046,9 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
         },
         Varlociraptor::DecodePHRED => {
             conversion::decode_phred::decode_phred()?;
+        }
+        Varlociraptor::Genotype => {
+            conversion::genotype::genotype()?;
         }
         Varlociraptor::Estimate { kind } => match kind {
             EstimateKind::MutationalBurden {

--- a/src/conversion/genotype.rs
+++ b/src/conversion/genotype.rs
@@ -1,0 +1,57 @@
+use crate::utils::get_event_tags;
+use anyhow::Result;
+use bio::stats::{PHREDProb, Prob};
+use itertools::Itertools;
+use rust_htslib::bcf;
+use rust_htslib::bcf::record::{GenotypeAllele, Numeric};
+use rust_htslib::bcf::Read;
+
+/// Decode PHRED scaled values to probabilities.
+pub(crate) fn genotype() -> Result<()> {
+    let mut inbcf = bcf::Reader::from_stdin()?;
+
+    // setup output file
+    let mut header = bcf::Header::from_template(inbcf.header());
+    header.push_record(b"##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">");
+
+    let mut outbcf = bcf::Writer::from_stdout(&header, false, bcf::Format::Bcf)?;
+
+    for record in inbcf.records() {
+        let mut record = record?;
+        let vafs = record.format(b"AF").float()?;
+        let dps = record.format(b"DP").integer()?;
+
+        outbcf.translate(&mut record);
+        let genotypes: Vec<_> = vafs
+            .iter()
+            .zip(dps.iter())
+            .map(|(vaf, dp)| {
+                let vaf = vaf[0];
+                let dp = dp[0];
+                if relative_eq!(vaf, 0.5) {
+                    [GenotypeAllele::Unphased(0), GenotypeAllele::Unphased(1)]
+                } else if relative_eq!(vaf, 1.0) {
+                    [GenotypeAllele::Unphased(1), GenotypeAllele::Unphased(1)]
+                } else if relative_eq!(vaf, 0.0) {
+                    [GenotypeAllele::Unphased(0), GenotypeAllele::Unphased(0)]
+                } else if !dp.is_missing() && dp > 0 {
+                    // VAF is < 1.0 but not exactly 0.5. Still infer heterozygous genotype because
+                    // it is the most likely case (in a subclone of the cells).
+                    [GenotypeAllele::Unphased(0), GenotypeAllele::Unphased(1)]
+                } else {
+                    // no observations
+                    [
+                        GenotypeAllele::UnphasedMissing,
+                        GenotypeAllele::UnphasedMissing,
+                    ]
+                }
+            })
+            .flatten()
+            .collect();
+        record.push_genotypes(&genotypes)?;
+
+        outbcf.write(&record)?;
+    }
+
+    Ok(())
+}

--- a/src/conversion/mod.rs
+++ b/src/conversion/mod.rs
@@ -1,1 +1,2 @@
 pub(crate) mod decode_phred;
+pub(crate) mod genotype;


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
