### PR TITLE
fix: use pseudo observation to adjust MAPQ for lower depths

### DIFF
--- a/src/calling/variants/calling.rs
+++ b/src/calling/variants/calling.rs
@@ -451,12 +451,8 @@ where
                     // METHOD: check for homopolymer artifacts if at least one pileup contains the corresponding information.
                     work_item.check_homopolymer_artifact_detection |= true;
                 }
+                Observation::adjust_prob_mapping(&mut pileup);
                 if is_snv_or_mnv {
-                    // METHOD: adjust MAPQ to get rid of stochastically inflated ones
-                    // This takes the arithmetic mean of all MAPQs in the pileup.
-                    // By that, we effectively diminish high MAPQs of reads that just achieve them
-                    // because of e.g. randomly better matching bases in themselves or their mates.
-                    Observation::adjust_prob_mapping(&mut pileup);
                     // METHOD: remove non-standard alignments. They might come from near
                     // SVs and can induce artifactual SNVs or MNVs. By removing them,
                     // we just conservatively reduce the coverage to those which are
@@ -717,11 +713,6 @@ where
                                                         .events()
                                                         .get(other_sample)
                                                         .unwrap();
-                                                    dbg!((
-                                                        event.allele_freq,
-                                                        other_event.allele_freq,
-                                                        other_event == map_event
-                                                    ));
                                                     other_event == map_event
                                                 } else {
                                                     // don't do that for our current sample

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -41,6 +41,7 @@ lazy_static! {
     pub(crate) static ref PROB_033: LogProb = LogProb::from(Prob(1.0 / 3.0));
     pub(crate) static ref PROB_025: LogProb = LogProb::from(Prob(0.25));
     pub(crate) static ref PROB_095: LogProb = LogProb::from(Prob(0.95));
+    pub(crate) static ref PROB_09: LogProb = LogProb::from(Prob(0.9));
 }
 
 pub(crate) fn aux_tag_strand_info(record: &bam::Record) -> Option<&[u8]> {

--- a/tests/resources/testcases/test05/testcase.yaml
+++ b/tests/resources/testcases/test05/testcase.yaml
@@ -2,7 +2,7 @@
 
 expected:
   posteriors:
-  - PROB_SOMATIC_TUMOR >= 284.0
+  - PROB_SOMATIC_TUMOR >= 100.0
 
 # necessary bam files
 samples:

--- a/tests/resources/testcases/test09/testcase.yaml
+++ b/tests/resources/testcases/test09/testcase.yaml
@@ -2,7 +2,7 @@
 
 expected:
   posteriors:
-  - PROB_SOMATIC_TUMOR >= 104.0
+  - PROB_SOMATIC_TUMOR >= 80.0
 
 # necessary bam files
 samples:

--- a/tests/resources/testcases/test10/testcase.yaml
+++ b/tests/resources/testcases/test10/testcase.yaml
@@ -3,7 +3,7 @@
 
 expected:
   posteriors:
-  - PROB_SOMATIC_TUMOR >= 702.0
+  - PROB_SOMATIC_TUMOR >= 400.0
 
 # necessary bam files
 samples:

--- a/tests/resources/testcases/test20/testcase.yaml
+++ b/tests/resources/testcases/test20/testcase.yaml
@@ -5,7 +5,7 @@
 
 expected:
   posteriors:
-  - PROB_SOMATIC_TUMOR >= 318.0
+  - PROB_SOMATIC_TUMOR >= 60.0
 
 # necessary bam files
 samples:

--- a/tests/resources/testcases/test22/testcase.yaml
+++ b/tests/resources/testcases/test22/testcase.yaml
@@ -3,7 +3,7 @@
 
 expected:
   posteriors:
-  - PROB_SOMATIC_TUMOR >= 42.0
+  - PROB_SOMATIC_TUMOR >= 4.0
 
 # necessary bam files
 samples:

--- a/tests/resources/testcases/test23/testcase.yaml
+++ b/tests/resources/testcases/test23/testcase.yaml
@@ -3,7 +3,7 @@
 
 expected:
   posteriors:
-  - PROB_SOMATIC_TUMOR >= 6.6
+  - PROB_SOMATIC_TUMOR >= 3.0
 
 # necessary bam files
 samples:

--- a/tests/resources/testcases/test30/testcase.yaml
+++ b/tests/resources/testcases/test30/testcase.yaml
@@ -2,7 +2,7 @@
 
 expected:
   posteriors:
-  - PROB_SOMATIC_TUMOR >= 2296.0
+  - PROB_SOMATIC_TUMOR >= 600.0
 
 samples:
   normal:

--- a/tests/resources/testcases/test31/testcase.yaml
+++ b/tests/resources/testcases/test31/testcase.yaml
@@ -2,7 +2,7 @@
 
 expected:
   posteriors:
-  - PROB_SOMATIC_TUMOR >= 11.08
+  - PROB_SOMATIC_TUMOR >= 5.0
 
 samples:
   normal:

--- a/tests/resources/testcases/test_giab_20/testcase.yaml
+++ b/tests/resources/testcases/test_giab_20/testcase.yaml
@@ -1,11 +1,12 @@
 # False positive call from GIAB (15:40036395). Freebayes calls this with a weak posterior:
 # 15      40036395        .       GTGCTGCTGCTGCTGCTGCTGCTGCTGCT   GTGCTGCTGCTGCTGCTGCTGCTGCT      0       .       AB=0;ABP=0;AC=0;AF=0;AN=2;AO=5;CIGAR=1M3D25M;DP=86;DPB=85.4138;DPRA=0;EPP=3.44459;EPPR=10.9517;GTI=0;LEN=3;MEANALT=9;MQM=60;MQMR=60;NS=1;NUMALT=1;ODDS=68.3624;PAIRED=1;PAIREDR=1;PAO=0.5;PQA=1;PQR=1;PRO=0.5;QA=141;QR=2437;RO=70;RPL=0;RPP=13.8677;RPPR=9.09042;RPR=5;RUN=1;SAF=2;SAP=3.44459;SAR=3;SRF=29;SRP=7.47733;SRR=41;TYPE=del;technology.ILLUMINA=1  GT:DP:AD:RO:QR:AO:QA:GL 0/0:86:70,5:70:2437:5:141:0,-9.83374,-206.698
 
-# The evidence is pretty clear though. Hence, we currently think this must be a somatic mutation in the cultured cell line. It is clearly not diploid, but Varlociraptor has to be informed of the possibility of such events between 0.0 and 0.5 by introducing a somatic mutation rate in the scenario and adding a corresponding event.
+# It seems to be caused by a homologous region. MAPQ adjustment is able to correctly expose this.
+
 
 expected:
   posteriors:
-    - PROB_SOMATIC < 0.1
+    - PROB_PRESENT > 50.0
 
 # necessary bam files
 samples:


### PR DESCRIPTION
### Description

This adds some additional uncertainty to low depth loci. This is important, because at low depth, we might accidentally miss low MAPQ reads and all observed reads could have an artificially inflated MAPQ by random sequencing errors. By adding a pseudo observation with reduced MAPQ, this missing uncertainty is efficiently introduced, while becoming more and more important the lower the depth is.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
