### PR TITLE
fix: handle absent strand information

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -60,7 +60,7 @@ pub(crate) enum Error {
     InvalidPriorConfiguration { msg: String },
     #[error("read position determined from cigar string exceeds record length")]
     ReadPosOutOfBounds,
-    #[error("invalid strand information '{value}', must be '+', '-', or '*'")]
+    #[error("invalid strand information '{value}', must be '+', '-', '*' or '.'")]
     InvalidStrandInfo { value: char },
     #[error("invalid read orientation information '{value}', must be 'F1R2', 'F2R1', etc.")]
     InvalidReadOrientationInfo { value: String },

--- a/src/variants/evidence/observation.rs
+++ b/src/variants/evidence/observation.rs
@@ -84,6 +84,7 @@ impl Strand {
             b'+' => Strand::Forward,
             b'-' => Strand::Reverse,
             b'*' => Strand::Both,
+            b'.' => Strand::None,
             _ => {
                 return Err(Error::InvalidStrandInfo {
                     value: char::from_u32(item as u32).unwrap(),


### PR DESCRIPTION
### Description

Currently varlociraptor fails when the strand information is absent in the strand-information-string.
Absent strand information is represented by `.`.
As the `Strand`-enum already contains `None` as possible object handling of the absent information only has the be added to the `from_aux_item`-function.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
