### PR TITLE
fix: Format field header for Allele Frequency Distribution should have `Number=.`, not `Number=A`

### DIFF
--- a/src/calling/variants/calling.rs
+++ b/src/calling/variants/calling.rs
@@ -202,7 +202,7 @@ where
               event (PROB_ARTIFACT).\">",
         );
         header.push_record(
-            b"##FORMAT=<ID=AFD,Number=A,Type=String,\
+            b"##FORMAT=<ID=AFD,Number=.,Type=String,\
               Description=\"Sampled posterior probability densities of allele frequencies in PHRED scale \
               (the smaller the higher, with 0 being equal to an unscaled probability of 1). \
               In the discrete case (no somatic mutation rate or continuous universe in the scenario), \


### PR DESCRIPTION
### Description

This fixes a typo in the VCF header for FORMAT/AFD, where Number was given as `A` (i.e. one entry per allele); Number should be `.` instead, since there are a variable number of key=value pairs encoded in this tag and varlociraptor generates exactly one record per allele.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
