### PR TITLE
fix: remove spurious homopolymer error calls

### DIFF
--- a/src/variants/evidence/observations/read_observation.rs
+++ b/src/variants/evidence/observations/read_observation.rs
@@ -550,6 +550,7 @@ where
                     if let Some(homopolymer_error_model) = homopolymer_error_model {
                         let ref_indel_len =
                             alt_indel_len + homopolymer_error_model.variant_homopolymer_indel_len();
+
                         if ref_indel_len == 0 {
                             // no homopolymer indel in read compared to reference
                             obs.homopolymer_indel_len(None)

--- a/src/variants/model/bias/homopolymer_error.rs
+++ b/src/variants/model/bias/homopolymer_error.rs
@@ -54,12 +54,18 @@ impl Bias for HomopolymerError {
         if !self.is_artifact() {
             return true;
         }
-        // METHOD: this bias is only relevant if there is at least one recorded indel operation (indel operations are only recorded for some variants).
-        pileups.iter().any(|pileup| {
+        // METHOD: this bias is only relevant if there is at least one recorded indel operation 
+        // (indel operations are only recorded for some variants) or no alt support
+        // observation in each sample.
+        pileups.iter().all(|pileup| {
+            !pileup.read_observations()
+                .iter()
+                .any(|obs| obs.is_strong_alt_support()) ||
             pileup
                 .read_observations()
                 .iter()
                 .any(|obs| self.is_bias_evidence(obs))
+            
         })
     }
 

--- a/src/variants/model/bias/homopolymer_error.rs
+++ b/src/variants/model/bias/homopolymer_error.rs
@@ -54,9 +54,7 @@ impl Bias for HomopolymerError {
         if !self.is_artifact() {
             return true;
         }
-        // METHOD: this bias is only relevant if there is at least one recorded indel operation 
-        // (indel operations are only recorded for some variants) or no alt support
-        // observation in each sample.
+        // METHOD: we require all alt supporting samples to have at least one homopolymer indel relative to the alt allele.
         pileups.iter().all(|pileup| {
             !pileup.read_observations()
                 .iter()

--- a/src/variants/model/bias/homopolymer_error.rs
+++ b/src/variants/model/bias/homopolymer_error.rs
@@ -56,14 +56,14 @@ impl Bias for HomopolymerError {
         }
         // METHOD: we require all alt supporting samples to have at least one homopolymer indel relative to the alt allele.
         pileups.iter().all(|pileup| {
-            !pileup.read_observations()
-                .iter()
-                .any(|obs| obs.is_strong_alt_support()) ||
-            pileup
+            !pileup
                 .read_observations()
                 .iter()
-                .any(|obs| self.is_bias_evidence(obs))
-            
+                .any(|obs| obs.is_strong_alt_support())
+                || pileup
+                    .read_observations()
+                    .iter()
+                    .any(|obs| self.is_bias_evidence(obs))
         })
     }
 


### PR DESCRIPTION
### Description

We require all alt supporting samples to have at least one homopolymer indel relative to the alt allele.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
