### PR TITLE
fix: check if cfg has_u128 or not

### DIFF
--- a/src/variants/evidence/realignment/edit_distance.rs
+++ b/src/variants/evidence/realignment/edit_distance.rs
@@ -44,7 +44,11 @@ impl EditDistanceCalculation {
         let l = read_seq.len();
         let read_seq = read_seq.collect();
 
-        let myers = if l <= 64 {
+        #[cfg(has_u128)]
+        let num_bits = 128;
+        #[cfg(not(has_u128))]
+        let num_bits = 64;
+        let myers = if l <= num_bits {
             Myers::Short(myers::Myers::new(&read_seq))
         } else {
             Myers::Long(long::Myers::new(&read_seq))

--- a/src/variants/evidence/realignment/edit_distance.rs
+++ b/src/variants/evidence/realignment/edit_distance.rs
@@ -44,7 +44,7 @@ impl EditDistanceCalculation {
         let l = read_seq.len();
         let read_seq = read_seq.collect();
 
-        let myers = if l <= 128 {
+        let myers = if l <= 64 {
             Myers::Short(myers::Myers::new(&read_seq))
         } else {
             Myers::Long(long::Myers::new(&read_seq))

--- a/src/variants/evidence/realignment/edit_distance.rs
+++ b/src/variants/evidence/realignment/edit_distance.rs
@@ -16,7 +16,10 @@ use crate::variants::evidence::realignment::pairhmm::{RefBaseEmission, EDIT_BAND
 use super::pairhmm::{ReadVsAlleleEmission, VariantEmission};
 
 enum Myers {
+    #[cfg(has_u128)]
     Short(myers::Myers<u128>),
+    #[cfg(not(has_u128))]
+    Short(myers::Myers<u64>),
     Long(long::Myers<u64>),
 }
 


### PR DESCRIPTION
### Description

With rust-bio 0.39.2, the BitVec trait has `#[cfg(has_u128)]` checks, so we also do those checks.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
