### PR TITLE
fix: only check for homopolymer errors if the indel operation is alone in the variant

### DIFF
--- a/src/calling/variants/calling.rs
+++ b/src/calling/variants/calling.rs
@@ -728,7 +728,6 @@ where
                                     let others_equal_map = || {
                                         map_estimates.events().iter().all(
                                             |(other_sample, map_event)| {
-                                                //dbg!((other_sample, sample, estimate.events().get(other_sample).unwrap(), map_event));
                                                 if other_sample != sample {
                                                     // check if other event is the same as the map event
                                                     let other_event = estimate

--- a/src/utils/homopolymers.rs
+++ b/src/utils/homopolymers.rs
@@ -24,8 +24,17 @@ impl HomopolymerIndelOperation {
         };
 
         if pattern.len() <= 256 {
-            let mut aligner = Aligner::with_scoring(Scoring::from_scores(-1, -1, 1, -1));
+            let mut aligner = Aligner::with_scoring(Scoring::from_scores(-2, -1, 1, -1));
             let best_aln = aligner.global(pattern, text);
+
+            if !is_single_indel(&best_aln.operations) {
+                // METHOD: if replacement contains either multiple indels or additional substitutions
+                // it is a complex variant which we do not consider for homopolymer errors.
+                // As we basically test whether the indel is in phase with the others in such
+                // cases, we should be safe in any case, as homopolymer errors are random and should
+                // not occur in phase with each other or substitutions.
+                return None;
+            }
 
             let mut ret =
                 HomopolymerIndelOperation::from_alignment(&text, &pattern, &best_aln.operations);
@@ -118,6 +127,21 @@ impl HomopolymerIndelOperation {
             base: homopolymer_base.unwrap(),
         })
     }
+}
+
+fn is_single_indel(alignment: &[AlignmentOperation]) -> bool {
+    let op_blocks = alignment
+        .iter()
+        .group_by(|op| *op)
+        .into_iter()
+        .filter(|(op, stretch)| match op {
+            AlignmentOperation::Del | AlignmentOperation::Ins | AlignmentOperation::Subst => true,
+            AlignmentOperation::Match => false,
+            _ => unreachable!("bug: unexpected alignment operation"),
+        })
+        .count();
+
+    op_blocks == 1
 }
 
 pub(crate) fn is_homopolymer_seq(seq: &[u8]) -> bool {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -224,8 +224,6 @@ testcase_should_panic!(test_overlapping_events, exact);
 testcase!(test_l2fc, exact, fast);
 testcase!(test_cmp, exact, fast);
 
-testcase!(ZNRF3_testcase, exact);
-
 fn basedir(test: &str) -> String {
     format!("tests/resources/{}", test)
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -224,6 +224,8 @@ testcase_should_panic!(test_overlapping_events, exact);
 testcase!(test_l2fc, exact, fast);
 testcase!(test_cmp, exact, fast);
 
+testcase!(ZNRF3_testcase, exact);
+
 fn basedir(test: &str) -> String {
     format!("tests/resources/{}", test)
 }


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
