### PR TITLE
feat: improved formula simplification for negations which can provide  major speedups and fixes a bug where part of the VAF spectrum is not missed in evalution. Further, it is now possible to define VAF sets as mysample:{0.5,1.0} in formulas and {0.0,0.5,1.0} in universe definitions.

### DIFF
--- a/src/grammar/formula.pest
+++ b/src/grammar/formula.pest
@@ -1,14 +1,16 @@
 universe = _{ SOI ~ ( vafdef ~ ( "|" ~ vafdef )* ) ~ EOI }
-vafdef = _{ vaf | vafrange }
+vafdef = _{ vaf | vafrange | vafset }
 vafrange = { bound ~ vaf ~ "," ~ vaf ~ bound }
+vafset = { "{" ~ vaf ~ ("," ~ vaf)+ ~ "}" }
 
 formula = _{ SOI ~ (conjunction | disjunction | negation | sample_vafdef | variant | expression | cmp | lfc | false_literal) ~ EOI }
 conjunction = { subformula ~ ( "&" ~ subformula )+ }
 disjunction = { subformula ~ ( "|" ~ subformula )+ }
 negation = { "!" ~ subformula }
 subformula = _{ variant | sample_vafdef | ("(" ~ conjunction ~ ")") | ("(" ~ disjunction ~ ")") | negation | expression | cmp | lfc | ("(" ~ subformula ~ ")") }
-sample_vafdef = _{ sample_vaf | sample_vafrange }
+sample_vafdef = _{ sample_vaf | sample_vafrange | sample_vafset }
 sample_vafrange = { identifier ~ ":" ~ vafrange }
+sample_vafset = { identifier ~ ":" ~ vafset }
 sample_vaf = { identifier ~ ":" ~ vaf }
 expression = { "$" ~ identifier }
 identifier = { (ASCII_ALPHANUMERIC | "_" | "-" | ".")+ }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -37,6 +37,14 @@ macro_rules! testcase {
                     )
                     .unwrap();
                     let mode = stringify!($pairhmm_mode);
+
+                    // setup logger
+                    // fern::Dispatch::new()
+                    // .level(log::LevelFilter::Info)
+                    // .chain(std::io::stderr())
+                    // .apply()
+                    // .unwrap();
+
                     testcase.run(mode).unwrap();
                     testcase.check();
                 }


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
