### PR TITLE
fix: convert empty VAF spectrum to false and ensure that an empty spectrum evaluates as zero probability

### DIFF
--- a/src/grammar/formula.rs
+++ b/src/grammar/formula.rs
@@ -129,7 +129,12 @@ impl FormulaTerminal {
                 },
             ) if sample_a == sample_b => match (&vafs_a, &vafs_b) {
                 (VAFSpectrum::Range(a), VAFSpectrum::Range(b)) => {
-                    *vafs_a = VAFSpectrum::Range(a & b)
+                    let intersection = a & b;
+                    if intersection.is_singleton() {
+                        *vafs_a = VAFSpectrum::singleton(a.start)
+                    } else {
+                        *vafs_a = VAFSpectrum::Range(a & b)
+                    }
                 }
                 (VAFSpectrum::Range(a), VAFSpectrum::Set(b)) => {
                     *vafs_a = VAFSpectrum::Set(
@@ -396,10 +401,7 @@ impl Formula {
     /// Return true if this formula is a terminal that is always false (an empty VAF set).
     pub(crate) fn is_terminal_false(&self) -> bool {
         match self {
-            Formula::Terminal(FormulaTerminal::Atom {
-                vafs: VAFSpectrum::Set(vafs),
-                ..
-            }) => vafs.is_empty(),
+            Formula::Terminal(FormulaTerminal::Atom { vafs, .. }) => vafs.is_empty(),
             Formula::Terminal(FormulaTerminal::False) => true,
             _ => false,
         }
@@ -1058,7 +1060,11 @@ impl VAFRange {
     }
 
     pub(crate) fn is_empty(&self) -> bool {
-        self.start == self.end
+        self.start == self.end && (self.left_exclusive || self.right_exclusive)
+    }
+
+    pub(crate) fn is_singleton(&self) -> bool {
+        self.start == self.end && !(self.left_exclusive || self.right_exclusive)
     }
 
     pub(crate) fn contains(&self, vaf: AlleleFreq) -> bool {

--- a/src/variants/model/modes/generic.rs
+++ b/src/variants/model/modes/generic.rs
@@ -276,7 +276,11 @@ impl GenericPosterior {
                         }
                     }
                     grammar::VAFSpectrum::Range(vafs) => {
-                        if is_clear_ref && *vafs.start > 0.0 {
+                        if vafs.is_empty() {
+                            // METHOD: empty interval, integral must be zero.
+                            return LogProb::ln_zero();
+                        }
+                        if is_clear_ref && (*vafs.start > 0.0) {
                             // METHOD: shortcut for the case that all obs support the reference but the vaf
                             // range in this event is > 0. Then, we don't need to recurse further and can
                             // immediately stop, returning a probability of zero.


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
