### PR TITLE
fix: fix insufficient data leading to probabilities of 0 leading to nulls in alignment properties

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -694,13 +694,13 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
                         0.,
                     )?;
 
-                    let gap_params = alignment_properties.gap_params().unwrap_or_default();
+                    let gap_params = alignment_properties.gap_params.clone();
 
                     let log_each_record = log_mode == "each-record";
 
                     match pairhmm_mode.as_ref() {
                         "homopolymer" => {
-                            let hop_params = alignment_properties.hop_params().unwrap_or_default();
+                            let hop_params = alignment_properties.hop_params.clone();
                             let mut processor =
                                 calling::variants::preprocessing::ObservationProcessor::builder()
                                     .alignment_properties(alignment_properties)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -694,13 +694,13 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
                         0.,
                     )?;
 
-                    let gap_params = alignment_properties.gap_params();
+                    let gap_params = alignment_properties.gap_params().unwrap_or_default();
 
                     let log_each_record = log_mode == "each-record";
 
                     match pairhmm_mode.as_ref() {
                         "homopolymer" => {
-                            let hop_params = alignment_properties.hop_params();
+                            let hop_params = alignment_properties.hop_params().unwrap_or_default();
                             let mut processor =
                                 calling::variants::preprocessing::ObservationProcessor::builder()
                                     .alignment_properties(alignment_properties)

--- a/src/estimation/alignment_properties.rs
+++ b/src/estimation/alignment_properties.rs
@@ -570,7 +570,8 @@ impl AlignmentProperties {
                     .map(|(_, c)| c)
                     .sum::<usize>()
             };
-            if ![2, -2].iter().any(|i| gap_counts_with_length(*i) > 0) || gaps.total_count() < 1000 {
+            if ![2, -2].iter().any(|i| gap_counts_with_length(*i) > 0) || gaps.total_count() < 1000
+            {
                 warn!("Insufficient observations for gap parameter estimation, falling back to default gap parameters");
                 return Err(anyhow!(
                     "Insufficient observations for gap parameter estimation"

--- a/src/estimation/alignment_properties.rs
+++ b/src/estimation/alignment_properties.rs
@@ -11,7 +11,7 @@ use std::ops::AddAssign;
 use std::str;
 use std::u32;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use bio::stats::{LogProb, Prob};
 use counter::Counter;
 use itertools::Itertools;
@@ -50,44 +50,6 @@ impl BackwardsCompatibility {
     fn default_max_mapq() -> u8 {
         60
     }
-
-    fn default_gap_params() -> GapParams {
-        GapParams {
-            prob_insertion_artifact: LogProb::from(Prob(2.8e-6)),
-            prob_deletion_artifact: LogProb::from(Prob(5.1e-6)),
-            prob_insertion_extend_artifact: LogProb::zero(),
-            prob_deletion_extend_artifact: LogProb::zero(),
-        }
-    }
-
-    fn default_hop_params() -> HopParams {
-        HopParams {
-            prob_seq_homopolymer: vec![
-                LogProb::zero(),
-                LogProb::zero(),
-                LogProb::zero(),
-                LogProb::zero(),
-            ],
-            prob_ref_homopolymer: vec![
-                LogProb::zero(),
-                LogProb::zero(),
-                LogProb::zero(),
-                LogProb::zero(),
-            ],
-            prob_seq_extend_homopolymer: vec![
-                LogProb::zero(),
-                LogProb::zero(),
-                LogProb::zero(),
-                LogProb::zero(),
-            ],
-            prob_ref_extend_homopolymer: vec![
-                LogProb::zero(),
-                LogProb::zero(),
-                LogProb::zero(),
-                LogProb::zero(),
-            ],
-        }
-    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -101,9 +63,9 @@ pub(crate) struct AlignmentProperties {
     pub(crate) max_mapq: u8,
     #[serde(skip, default)]
     pub(crate) cigar_counts: Option<CigarStats>,
-    #[serde(default = "BackwardsCompatibility::default_gap_params")]
+    #[serde(default)]
     pub(crate) gap_params: GapParams,
-    #[serde(default = "BackwardsCompatibility::default_hop_params")]
+    #[serde(default)]
     pub(crate) hop_params: HopParams,
     #[serde(default = "BackwardsCompatibility::default_homopolymer_error_model")]
     pub(crate) wildtype_homopolymer_error_model: HashMap<i16, f64>,
@@ -192,8 +154,8 @@ impl AlignmentProperties {
             cigar_counts: Default::default(),
             wildtype_homopolymer_error_model: HashMap::new(),
             initial: true,
-            gap_params: BackwardsCompatibility::default_gap_params(),
-            hop_params: BackwardsCompatibility::default_hop_params(),
+            gap_params: Default::default(),
+            hop_params: Default::default(),
             epsilon_gap,
         };
 
@@ -226,7 +188,7 @@ impl AlignmentProperties {
             insert_size: Option<f64>,
         }
 
-        #[derive(Default)]
+        #[derive(Default, Debug)]
         struct AlignmentStats {
             n_reads: usize,
             max_mapq: u8,
@@ -319,8 +281,8 @@ impl AlignmentProperties {
 
         properties.wildtype_homopolymer_error_model = properties.wildtype_homopolymer_error_model();
 
-        properties.gap_params = properties.gap_params();
-        properties.hop_params = properties.hop_params();
+        properties.gap_params = properties.gap_params().unwrap_or_default();
+        properties.hop_params = properties.hop_params().unwrap_or_default();
 
         properties.max_read_len = all_stats.max_read_len;
         properties.max_del_cigar_len = all_stats.max_del;
@@ -599,7 +561,7 @@ fn cigar_stats(record: &bam::Record, refseq: &[u8], allow_hardclips: bool) -> Ci
 }
 
 impl AlignmentProperties {
-    pub(crate) fn gap_params(&self) -> GapParams {
+    pub(crate) fn gap_params(&self) -> Result<GapParams> {
         if let Some(cigar_counts) = &self.cigar_counts {
             let gaps = &cigar_counts.gap_counts;
             let gap_counts_with_length = |length: isize| {
@@ -608,6 +570,12 @@ impl AlignmentProperties {
                     .map(|(_, c)| c)
                     .sum::<usize>()
             };
+            if ![2, -2].iter().any(|i| gap_counts_with_length(*i) > 0) || gaps.total_count() < 100 {
+                warn!("Insufficient observations for gap parameter estimation, falling back to default gap parameters");
+                return Err(anyhow!(
+                    "Insufficient observations for gap parameter estimation"
+                ));
+            }
 
             let [(del_open, del_extend), (ins_open, ins_extend)] = [-1, 1].map(|sign| {
                 let num_gap1 = gap_counts_with_length(sign);
@@ -624,7 +592,7 @@ impl AlignmentProperties {
                 (gap_open, gap_extend)
             });
 
-            GapParams {
+            Ok(GapParams {
                 prob_insertion_artifact: LogProb::from(
                     Prob::checked(ins_open).unwrap_or_else(|_| Prob::zero()),
                 ),
@@ -637,15 +605,18 @@ impl AlignmentProperties {
                 prob_deletion_extend_artifact: LogProb::from(
                     Prob::checked(del_extend).unwrap_or_else(|_| Prob::zero()),
                 ),
-            }
+            })
         } else {
-            // if we didn't count any gaps, assume default gap rates
-            self.gap_params.clone()
+            warn!("No cigar operations counted, falling back to default gap parameters.");
+            Err(anyhow!(
+                "Insufficient observations for gap parameter estimation"
+            ))
         }
     }
 
-    pub(crate) fn hop_params(&self) -> HopParams {
+    pub(crate) fn hop_params(&self) -> Result<HopParams> {
         if let Some(cigar_counts) = &self.cigar_counts {
+            let mut insufficient_counts = false;
             let empty = SimpleCounter::default();
             let counts = |base| {
                 cigar_counts
@@ -678,6 +649,10 @@ impl AlignmentProperties {
                     let prob_ins_hop_start_or_extend =
                         num_diff_1_ins_events as f64 / num_diff_1_ins_bases as f64;
 
+                    if num_diff_1_del_events < 100 || num_diff_1_ins_events < 100 {
+                        insufficient_counts |= true;
+                    }
+
                     let prob_ins = LogProb::from(
                         Prob::checked(prob_ins_hop_start_or_extend)
                             .unwrap_or_else(|_| Prob::zero()),
@@ -689,14 +664,24 @@ impl AlignmentProperties {
                     ((prob_ins, prob_del), (prob_ins, prob_del))
                 })
                 .unzip();
-            HopParams {
+
+            if insufficient_counts {
+                warn!("Insufficient observations for hop parameter estimation, falling back to default hop parameters");
+                return Err(anyhow!(
+                    "Insufficient observations for hop parameter estimation"
+                ));
+            }
+            Ok(HopParams {
                 prob_seq_homopolymer,
                 prob_ref_homopolymer,
                 prob_seq_extend_homopolymer,
                 prob_ref_extend_homopolymer,
-            }
+            })
         } else {
-            self.hop_params.clone()
+            warn!("Insufficient observations for hop parameter estimation, falling back to default hop parameters");
+            Err(anyhow!(
+                "No cigar operations counted, falling back to default hop parameters"
+            ))
         }
     }
 

--- a/src/estimation/alignment_properties.rs
+++ b/src/estimation/alignment_properties.rs
@@ -570,7 +570,7 @@ impl AlignmentProperties {
                     .map(|(_, c)| c)
                     .sum::<usize>()
             };
-            if ![2, -2].iter().any(|i| gap_counts_with_length(*i) > 0) || gaps.total_count() < 100 {
+            if ![2, -2].iter().any(|i| gap_counts_with_length(*i) > 0) || gaps.total_count() < 1000 {
                 warn!("Insufficient observations for gap parameter estimation, falling back to default gap parameters");
                 return Err(anyhow!(
                     "Insufficient observations for gap parameter estimation"

--- a/src/estimation/alignment_properties.rs
+++ b/src/estimation/alignment_properties.rs
@@ -281,8 +281,8 @@ impl AlignmentProperties {
 
         properties.wildtype_homopolymer_error_model = properties.wildtype_homopolymer_error_model();
 
-        properties.gap_params = properties.gap_params().unwrap_or_default();
-        properties.hop_params = properties.hop_params().unwrap_or_default();
+        properties.gap_params = properties.estimate_gap_params().unwrap_or_default();
+        properties.hop_params = properties.estimate_hop_params().unwrap_or_default();
 
         properties.max_read_len = all_stats.max_read_len;
         properties.max_del_cigar_len = all_stats.max_del;
@@ -561,7 +561,7 @@ fn cigar_stats(record: &bam::Record, refseq: &[u8], allow_hardclips: bool) -> Ci
 }
 
 impl AlignmentProperties {
-    pub(crate) fn gap_params(&self) -> Result<GapParams> {
+    pub(crate) fn estimate_gap_params(&self) -> Result<GapParams> {
         if let Some(cigar_counts) = &self.cigar_counts {
             let gaps = &cigar_counts.gap_counts;
             let gap_counts_with_length = |length: isize| {
@@ -615,7 +615,7 @@ impl AlignmentProperties {
         }
     }
 
-    pub(crate) fn hop_params(&self) -> Result<HopParams> {
+    pub(crate) fn estimate_hop_params(&self) -> Result<HopParams> {
         if let Some(cigar_counts) = &self.cigar_counts {
             let mut insufficient_counts = false;
             let empty = SimpleCounter::default();


### PR DESCRIPTION
### Description

This PR tackles two things:
1. If there are insufficient observations during parameter estimation for gaps and hops, use defaults instead
2. If there are probabilities of 0 in the gap/hop parameters, the log probabilities will be -inf, and -inf is serialized as null because json has no concept of +-inf and NaN. (We can either wrap these in some enum or perhaps switch to yaml)

### QC

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
