### PR TITLE
feat: report read id for each observation; this information can be used by phasing algorithms to combine evidence from multiple variants covered by the same read

### DIFF
--- a/src/variants/evidence/observations/id_factory.rs
+++ b/src/variants/evidence/observations/id_factory.rs
@@ -1,0 +1,51 @@
+use std::collections::HashMap;
+
+use bio_types::genome::AbstractLocus;
+
+use super::read_observation::Evidence;
+
+#[derive(Default, Debug)]
+pub(crate) struct ObservationIdFactory {
+    last_ends: HashMap<String, u64>,
+    ids: HashMap<Vec<u8>, u64>,
+    next_id: u64,
+}
+
+impl ObservationIdFactory {
+    pub(crate) fn register<E>(&mut self, evidence: &E) -> u64
+    where
+        E: Evidence,
+    {
+        // check whether ids can be reset
+        let start_locus = evidence.start_locus();
+        if let Some(last_end) = self.last_ends.get(start_locus.contig()) {
+            if *last_end < start_locus.pos() {
+                self.last_ends.remove(start_locus.contig());
+            }
+        }
+        if self.last_ends.is_empty() {
+            // no overlapping end remaining, set next_id to 0
+            self.next_id = 0;
+        }
+
+        // record end
+        let end_locus = evidence.end_locus();
+        let last_end = self
+            .last_ends
+            .entry(end_locus.contig().to_owned())
+            .or_default();
+        if *last_end < end_locus.pos() {
+            *last_end = end_locus.pos();
+        }
+
+        let name = evidence.name();
+
+        if let Some(id) = self.ids.get(name) {
+            *id
+        } else {
+            let id = self.next_id;
+            self.ids.insert(name.to_owned(), id);
+            id
+        }
+    }
+}

--- a/src/variants/evidence/observations/mod.rs
+++ b/src/variants/evidence/observations/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod depth_observation;
+pub(crate) mod id_factory;
 pub(crate) mod pileup;
 pub(crate) mod read_observation;
 

--- a/src/variants/sample.rs
+++ b/src/variants/sample.rs
@@ -25,6 +25,7 @@ use crate::variants::evidence::observations::read_observation::{
 use crate::variants::model::VariantType;
 use crate::variants::{self, types::Variant};
 
+use super::evidence::observations::id_factory::ObservationIdFactory;
 use super::evidence::observations::read_observation::major_alt_locus;
 use super::evidence::realignment::Realignable;
 use crate::variants::evidence::observations::pileup::Pileup;
@@ -195,6 +196,8 @@ pub(crate) struct Sample {
     #[builder(default = "Vec::new()")]
     omit_repeat_regions: Vec<VariantType>,
     protocol_strandedness: ProtocolStrandedness,
+    #[builder(default)]
+    observation_id_factory: ObservationIdFactory,
 }
 
 impl SampleBuilder {
@@ -248,6 +251,7 @@ impl Sample {
             &mut self.alignment_properties,
             self.max_depth,
             alt_variants,
+            &mut self.observation_id_factory,
         )?;
         // Process for each observation whether it is from the major read position or not.
         let major_pos = major_read_position(&observations);

--- a/src/variants/types/mod.rs
+++ b/src/variants/types/mod.rs
@@ -40,6 +40,7 @@ pub(crate) use none::None;
 pub(crate) use replacement::Replacement;
 pub(crate) use snv::Snv;
 
+use super::evidence::observations::id_factory::ObservationIdFactory;
 use super::evidence::realignment::Realignable;
 
 #[derive(Debug, CopyGetters, Getters, Builder)]
@@ -173,6 +174,7 @@ where
         alignment_properties: &mut AlignmentProperties,
         max_depth: usize,
         alt_variants: &[Box<dyn Realignable>],
+        observation_id_factory: &mut ObservationIdFactory,
     ) -> Result<Vec<ReadObservation>> {
         let locus = self.loci();
         buffer.fetch(locus, false)?;
@@ -209,6 +211,7 @@ where
                     alignment_properties,
                     &homopolymer_error_model,
                     alt_variants,
+                    observation_id_factory,
                 )? {
                     observations.push(obs);
                 }
@@ -254,6 +257,7 @@ where
         alignment_properties: &mut AlignmentProperties,
         max_depth: usize,
         alt_variants: &[Box<dyn Realignable>],
+        observation_id_factory: &mut ObservationIdFactory,
     ) -> Result<Vec<ReadObservation>> {
         // We cannot use a hash function here because candidates have to be considered
         // in a deterministic order. Otherwise, subsampling high-depth regions will result
@@ -353,6 +357,7 @@ where
                     alignment_properties,
                     &homopolymer_error_model,
                     alt_variants,
+                    observation_id_factory,
                 )? {
                     observations.push(obs);
                 }


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
