### PR TITLE
chore: Make UnsortedVariantFile error more informative

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,3 +1,4 @@
+use bio_types::genome::Locus;
 use std::path::PathBuf;
 
 use thiserror::Error;
@@ -66,8 +67,11 @@ pub(crate) enum Error {
     InvalidReadOrientationInfo { value: String },
     #[error("the following events are not disjunct: {expressions}")]
     OverlappingEvents { expressions: String },
-    #[error("the input VCF/BCF is not sorted")]
-    UnsortedVariantFile,
+    #[error("the input VCF/BCF is not sorted: {previous_locus:?} > {current_locus:?}")]
+    UnsortedVariantFile {
+        previous_locus: Locus,
+        current_locus: Locus,
+    },
     // #[error("invalid phase set, PS tag only supported for single sample VCF/BCF, may only contain a single value, and records may only contain a single ALT allele")]
     // InvalidPhaseSet,
     #[error("haplotype block consisting of normal variants in combination with breakends: this is currently unsupported")]

--- a/src/utils/variant_buffer.rs
+++ b/src/utils/variant_buffer.rs
@@ -77,7 +77,11 @@ impl VariantBuffer {
                                 && locus.pos() < previous_locus.pos()
                             {
                                 // unsorted input file, fail with an error
-                                return Err(errors::Error::UnsortedVariantFile.into());
+                                return Err(errors::Error::UnsortedVariantFile {
+                                    previous_locus: previous_locus.clone(),
+                                    current_locus: locus.clone(),
+                                }
+                                .into());
                             }
                             self.state = State::LocusComplete;
                         } else {

--- a/src/utils/variant_buffer.rs
+++ b/src/utils/variant_buffer.rs
@@ -79,7 +79,7 @@ impl VariantBuffer {
                                 // unsorted input file, fail with an error
                                 return Err(errors::Error::UnsortedVariantFile {
                                     previous_locus: previous_locus.clone(),
-                                    current_locus: locus.clone(),
+                                    current_locus: locus,
                                 }
                                 .into());
                             }


### PR DESCRIPTION
### Description

This PR includes the two loci which violate the `previous_locus <= current_locus` condition in the error.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
