### PR TITLE
feat: allow to omit alt-locus-bias

### DIFF
--- a/src/calling/variants/calling.rs
+++ b/src/calling/variants/calling.rs
@@ -54,6 +54,7 @@ where
     omit_read_position_bias: bool,
     omit_softclip_bias: bool,
     omit_homopolymer_artifact_detection: bool,
+    omit_alt_locus_bias: bool,
     scenario: grammar::Scenario,
     outbcf: Option<PathBuf>,
     contaminations: grammar::SampleInfo<Option<Contamination>>,
@@ -366,6 +367,7 @@ where
                 work_item.check_read_position_bias,
                 work_item.check_softclip_bias,
                 work_item.check_homopolymer_artifact_detection,
+                work_item.check_alt_locus_bias,
             )?;
 
             self.call_record(&mut work_item, _model, _events);
@@ -449,6 +451,7 @@ where
             check_read_position_bias: is_snv_or_mnv && !self.omit_read_position_bias,
             check_softclip_bias: is_snv_or_mnv && !self.omit_softclip_bias,
             check_homopolymer_artifact_detection: false,
+            check_alt_locus_bias: !self.omit_alt_locus_bias,
         };
 
         if let Some(ref haplotype) = work_item.haplotype {
@@ -509,6 +512,7 @@ where
         consider_read_position_bias: bool,
         consider_softclip_bias: bool,
         consider_homopolymer_error: bool,
+        consider_alt_locus_bias: bool,
     ) -> Result<()> {
         if !rid.map_or(false, |rid: u32| current_rid == rid) || events.is_empty() {
             // rid is not the same as before or the model mode has changed to something new, obtain event universe
@@ -536,6 +540,7 @@ where
                     consider_read_position_bias,
                     consider_softclip_bias,
                     consider_homopolymer_error,
+                    consider_alt_locus_bias,
                 )
                 .collect();
 
@@ -788,4 +793,5 @@ struct WorkItem {
     check_read_position_bias: bool,
     check_softclip_bias: bool,
     check_homopolymer_artifact_detection: bool,
+    check_alt_locus_bias: bool,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -452,6 +452,14 @@ pub enum CallKind {
         #[serde(default)]
         omit_homopolymer_artifact_detection: bool,
         #[structopt(
+            long = "omit-alt-locus-bias",
+            help = "Do not consider alt locus bias when calculating the probability of an artifact. \
+                   Use this flag when you have e.g. prior knowledge about all candidate variants being not \
+                   caused by mapping artifacts."
+        )]
+        #[serde(default)]
+        omit_alt_locus_bias: bool,
+        #[structopt(
             long = "testcase-locus",
             help = "Create a test case for the given locus. Locus must be given in the form \
                     CHROM:POS[:IDX]. IDX is thereby an optional value to select a particular \
@@ -801,6 +809,7 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
                     omit_read_position_bias,
                     omit_softclip_bias,
                     omit_homopolymer_artifact_detection,
+                    omit_alt_locus_bias,
                     testcase_locus,
                     testcase_prefix,
                     testcase_anonymous,

--- a/src/variants/model/bias/mod.rs
+++ b/src/variants/model/bias/mod.rs
@@ -134,12 +134,14 @@ impl Artifacts {
         consider_read_position_bias: bool,
         consider_softclip_bias: bool,
         consider_homopolymer_error: bool,
+        consider_alt_locus_bias: bool,
     ) -> Box<dyn Iterator<Item = Self>> {
         if !consider_strand_bias
             && !consider_read_orientation_bias
             && !consider_read_position_bias
             && !consider_softclip_bias
             && !consider_homopolymer_error
+            && !consider_alt_locus_bias
         {
             return Box::new(std::iter::empty());
         }
@@ -169,8 +171,11 @@ impl Artifacts {
         } else {
             vec![HomopolymerError::default()]
         };
-        let alt_locus_bias = AltLocusBias::iter().collect_vec();
-        //let alt_locus_bias = vec![AltLocusBias::None];
+        let alt_locus_bias = if consider_alt_locus_bias {
+            AltLocusBias::iter().collect_vec()
+        } else {
+            vec![AltLocusBias::default()]
+        };
 
         Box::new(
             strand_biases


### PR DESCRIPTION
### Description

Adds CLI option --omit-alt-locus-bias, to disable the consideration of alt locus bias when calling variants.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
