### PR TITLE
fix: Adhere to number specifications from VCF v4.3

### DIFF
--- a/src/calling/variants/preprocessing/mod.rs
+++ b/src/calling/variants/preprocessing/mod.rs
@@ -82,24 +82,24 @@ impl<R: realignment::Realigner + Clone + std::marker::Send + std::marker::Sync>
 
         // register tags
         header.push_record(
-            b"##INFO=<ID=SVLEN,Number=A,Type=Integer,\
+            b"##INFO=<ID=SVLEN,Number=.,Type=Integer,\
               Description=\"Difference in length between REF and ALT alleles\">",
         );
         header.push_record(
-            b"##INFO=<ID=END,Number=A,Type=Integer,\
+            b"##INFO=<ID=END,Number=1,Type=Integer,\
               Description=\"End position of structural variant (inclusive, 1-based).\">",
         );
         header.push_record(
-            b"##INFO=<ID=SVTYPE,Number=A,Type=String,\
-              Description=\"Structural variant type\">",
+            b"##INFO=<ID=SVTYPE,Number=1,Type=String,\
+              Description=\"Type of structural variant\">",
         );
         header.push_record(
-            b"##INFO=<ID=EVENT,Number=A,Type=String,\
+            b"##INFO=<ID=EVENT,Number=1,Type=String,\
               Description=\"ID of event associated to breakend\">",
         );
         header.push_record(
-            b"##INFO=<ID=MATEID,Number=1,Type=String,\
-              Description=\"ID of mate breakend\">",
+            b"##INFO=<ID=MATEID,Number=.,Type=String,\
+              Description=\"ID of mate breakends\">",
         );
 
         // register sequences


### PR DESCRIPTION
### Description

This PR adjusts the `Number=X` information of the VCF header written in the preprocessing step such that it matches the VCF specification v4.3.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
