### PR TITLE
fix: do not skip haplotype determination if SVTYPE tag is not present in VCF

### DIFF
--- a/src/calling/variants/preprocessing/haplotype_feature_index.rs
+++ b/src/calling/variants/preprocessing/haplotype_feature_index.rs
@@ -14,7 +14,7 @@ pub(crate) struct HaplotypeFeatureIndex {
 impl HaplotypeFeatureIndex {
     pub(crate) fn new<P: AsRef<Path>>(inbcf: P) -> Result<Self> {
         let mut bcf_reader = bcf::Reader::from_path(inbcf)?;
-        if !utils::is_sv_bcf(&bcf_reader) {
+        if !utils::is_haplotype_bcf(&bcf_reader) {
             return Ok(HaplotypeFeatureIndex::default());
         }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -53,10 +53,10 @@ pub(crate) fn aux_tag_strand_info(record: &bam::Record) -> Option<&[u8]> {
     }
 }
 
-pub(crate) fn is_sv_bcf(reader: &bcf::Reader) -> bool {
+pub(crate) fn is_haplotype_bcf(reader: &bcf::Reader) -> bool {
     for rec in reader.header().header_records() {
         if let bcf::header::HeaderRecord::Info { values, .. } = rec {
-            if values.get("ID").map_or(false, |id| id == "SVTYPE") {
+            if values.get("ID").map_or(false, |id| id == "EVENT") {
                 return true;
             }
         }


### PR DESCRIPTION
### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
