### PR TITLE
feat: add MATEID based recognition of connected breakends

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -76,6 +76,8 @@ pub(crate) enum Error {
     // InvalidPhaseSet,
     #[error("haplotype block consisting of normal variants in combination with breakends: this is currently unsupported")]
     HaplotypeBlockWithBreakend,
+    #[error("breakend with MATEID found that does not have its own ID set: this is currently unsupported, as there is no way to uniquely identify the pair")]
+    BreakendMateidWithoutRecid,
 }
 
 pub(crate) fn invalid_bcf_record(chrom: &str, pos: i64, msg: &str) -> Error {


### PR DESCRIPTION
Before, only EVENT tags where supported. Now, also MATEID without an EVENT tag is enough to construct a pair of connected breakends.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
