### PR TITLE
feat: if present, parse EF tag and consider single end reads marked to entirely cover the originating fragment for insert size statistics.

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -57,6 +57,16 @@ pub(crate) fn aux_tag_strand_info(record: &bam::Record) -> Option<&[u8]> {
     }
 }
 
+pub(crate) fn aux_tag_is_entire_fragment(record: &bam::Record) -> bool {
+    match record.aux(b"EF") {
+        Ok(bam::record::Aux::I8(entire_fragment)) => entire_fragment == 1,
+        Ok(bam::record::Aux::I16(entire_fragment)) => entire_fragment == 1,
+        Ok(bam::record::Aux::I32(entire_fragment)) => entire_fragment == 1,
+        Ok(bam::record::Aux::I64(entire_fragment)) => entire_fragment == 1,
+        _ => false,
+    }
+}
+
 /// Checks whether the given BCF contains fields required for evaluating haplotypes.
 /// Currently, this means that the EVENT or the MATEID field has to be defined in the
 /// header.


### PR DESCRIPTION

### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
