### PR TITLE
fix: match EF-tag

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -59,8 +59,11 @@ pub(crate) fn aux_tag_strand_info(record: &bam::Record) -> Option<&[u8]> {
 
 pub(crate) fn aux_tag_is_entire_fragment(record: &bam::Record) -> bool {
     match record.aux(b"EF") {
+        Ok(bam::record::Aux::U8(entire_fragment)) => entire_fragment == 1,
         Ok(bam::record::Aux::I8(entire_fragment)) => entire_fragment == 1,
+        Ok(bam::record::Aux::U16(entire_fragment)) => entire_fragment == 1,
         Ok(bam::record::Aux::I16(entire_fragment)) => entire_fragment == 1,
+        Ok(bam::record::Aux::U32(entire_fragment)) => entire_fragment == 1,
         Ok(bam::record::Aux::I32(entire_fragment)) => entire_fragment == 1,
         _ => false,
     }


### PR DESCRIPTION
### Description

When checking for the presence of the `EF`-tag, it is never found because rust-htslib interprets it as an unsigned integer.
For the tag being recognized I have added the U8 to U32 enums leaving the signed integers untouched as I am not aware if there could be scenarios where the tag is parsed as an signed integer.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
