### PR TITLE
feat: by default, use prior to guard absence or presence of variant but weight all decisions about other events just by the observations

### DIFF
--- a/src/calling/variants/calling.rs
+++ b/src/calling/variants/calling.rs
@@ -938,6 +938,7 @@ pub(crate) fn call_generic<CP, CF>(
     call_processor: CP,
     candidate_filter: CF,
     propagate_info_fields: Vec<String>,
+    full_prior: bool,
 ) -> Result<()>
 where
     CP: CallProcessor,
@@ -987,6 +988,7 @@ where
                 .and_then(|species| species.heterozygosity().map(|het| LogProb::from(Prob(het)))),
         )
         .variant_type_fractions(scenario.variant_type_fractions())
+        .is_absent_only(!full_prior)
         .build();
 
     // setup caller

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -529,6 +529,19 @@ pub enum CallKind {
         #[serde(default)]
         omit_alt_locus_bias: bool,
         #[structopt(
+            long = "full-prior",
+            help = "Compute the full prior distribution for any allele frequency combination. \
+                    This is in contrast to the default behavior, where the prior is only used to \
+                    distinguish between absence and presence of variants \
+                    (in essence we calculate the prior probability for the variant to be not present given all \
+                    provided mutation rates and the heterozygosity). \
+                    The advantage of this default behavior is that observations become in any case more important \
+                    than the prior to distinguish between different events, while the prior still effectively protects \
+                    from false positives."
+        )]
+        #[serde(default)]
+        full_prior: bool,
+        #[structopt(
             long = "testcase-locus",
             help = "Create a test case for the given locus. Locus must be given in the form \
                     CHROM:POS[:IDX]. IDX is thereby an optional value to select a particular \
@@ -896,6 +909,7 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
                     output,
                     log_mode,
                     propagate_info_fields,
+                    full_prior,
                 } => {
                     let testcase_builder = if let Some(testcase_locus) = testcase_locus {
                         if let Some(testcase_prefix) = testcase_prefix {
@@ -968,6 +982,7 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
                                     CallWriter::new(),
                                     DefaultCandidateFilter::new(),
                                     propagate_info_fields,
+                                    full_prior,
                                 )?;
                             } else {
                                 return Err(errors::Error::InvalidObservationsSpec.into());
@@ -1052,6 +1067,7 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
                                 CallWriter::new(),
                                 DefaultCandidateFilter::new(),
                                 propagate_info_fields,
+                                full_prior,
                             )?;
                         }
                     }
@@ -1229,6 +1245,7 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
                         species.heterozygosity().map(|het| LogProb::from(Prob(het)))
                     }))
                     .variant_type(Some(VariantType::Snv))
+                    .is_absent_only(false) // TODO make configurable with this as the default
                     .build();
                 prior.check()?;
 

--- a/src/estimation/contamination.rs
+++ b/src/estimation/contamination.rs
@@ -475,5 +475,6 @@ pub(crate) fn estimate_contamination(
         ContaminationEstimator::new(output, output_plot, output_max_vaf_variants, prior_estimate),
         ContaminationCandidateFilter::new(),
         Vec::new(),
+        false,
     )
 }

--- a/src/testcase/runner/common/mod.rs
+++ b/src/testcase/runner/common/mod.rs
@@ -18,6 +18,7 @@ use std::str;
 
 use anyhow::Result;
 use bio::io::fasta;
+use bio::stats::{PHREDProb, Prob};
 use eval::Expr;
 use itertools::Itertools;
 use rust_htslib::bcf::Read as BCFRead;
@@ -291,6 +292,7 @@ pub trait Testcase {
                                 .collect_vec(),
                         },
                         log_mode: "default".to_owned(),
+                        full_prior: false,
                     },
                 };
 
@@ -319,6 +321,7 @@ pub trait Testcase {
                             purity: self.purity().unwrap(),
                         },
                         log_mode: "default".to_owned(),
+                        full_prior: false,
                     },
                 };
 
@@ -367,7 +370,11 @@ pub trait Testcase {
                                 let id = values.get("ID").unwrap().clone();
                                 if id.starts_with("PROB_") {
                                     if let Ok(Some(values)) = call.info(id.as_bytes()).float() {
-                                        expr = expr.value(id.clone(), values[0])
+                                        expr = expr.value(id.clone(), values[0]);
+                                        expr = expr.value(
+                                            format!("PLAIN_{id}"),
+                                            Prob::from(PHREDProb(values[0] as f64)),
+                                        );
                                     }
                                 }
                             }

--- a/src/variants/model/likelihood.rs
+++ b/src/variants/model/likelihood.rs
@@ -23,8 +23,20 @@ pub(crate) struct Event {
 }
 
 impl Event {
+    pub(crate) fn absent() -> Self {
+        Event {
+            allele_freq: AlleleFreq(0.0),
+            artifacts: Artifacts::none(),
+            is_discrete: true,
+        }
+    }
+
     pub(crate) fn is_artifact(&self) -> bool {
         self.artifacts.is_artifact()
+    }
+
+    pub(crate) fn is_absent(&self) -> bool {
+        *self.allele_freq == 0.0
     }
 }
 

--- a/src/variants/model/modes/generic.rs
+++ b/src/variants/model/modes/generic.rs
@@ -140,6 +140,10 @@ impl LikelihoodOperands {
     pub(crate) fn is_discrete(&self) -> bool {
         self.events.values().all(|evt| evt.is_discrete)
     }
+
+    pub(crate) fn is_absent(&self) -> bool {
+        self.events.values().all(|evt| evt.is_absent())
+    }
 }
 
 impl Index<usize> for LikelihoodOperands {


### PR DESCRIPTION
This results in more intuitive classifications, and also avoids pitfalls generated by very low mutation rates.

An example for such a pitfall is the case where the somatic mutation rate is set much lower in the normal sample than in a tumor sample. In such cases, it could have happened that Varlociraptor puts aside the evidence for the variant being somatic in the normal sample just because it is cheaper to consider it a tumor sample only variant. While this is statistically correct given the prior beliefs in that case, it makes the model very dependent on those priors being chosen correctly, which is in practice very difficult.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
