### PR TITLE
feat!: when reporting observations, provide ref and alt support as kass raftery scores (RV=very strong ref support, AV=very strong alt support, RP=positive ref support, AP=positive alt support). This is a breaking change, as any parsing of SOBS and OBS will have to be adapted to these new two letter scores.

### DIFF
--- a/src/calling/variants/mod.rs
+++ b/src/calling/variants/mod.rs
@@ -244,7 +244,7 @@ impl Call {
                     i,
                     utils::generalized_cigar(
                         sample_info.pileup.read_observations().iter().map(|obs| {
-                            let score = utils::bayes_factor_to_letter(obs.bayes_factor_alt());
+                            let score = obs.max_bayes_factor().to_string();
                             format!(
                                 "{}{}{}{}{}{}{}{}",
                                 if obs.is_max_mapq {
@@ -299,7 +299,7 @@ impl Call {
                     i,
                     utils::generalized_cigar(
                         sample_info.pileup.read_observations().iter().map(|obs| {
-                            let score = utils::bayes_factor_to_letter(obs.bayes_factor_alt());
+                            let score = obs.max_bayes_factor().to_string();
                             format!(
                                 "{}",
                                 if obs.is_max_mapq {


### PR DESCRIPTION
### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
