### PR TITLE
fix: fixed handling of allele frequency boundaries (avoiding NaN probabilities in some rare cases); fixed handling of upper reference bound when estimating probability of third allele

### DIFF
--- a/src/calling/variants/mod.rs
+++ b/src/calling/variants/mod.rs
@@ -469,7 +469,7 @@ impl Call {
                 .values()
                 .map(|n| **n as i32)
                 .collect_vec();
-            record.push_format_integer(b"OOBS", &oobs);
+            record.push_format_integer(b"OOBS", &oobs)?;
 
             let sb = strand_bias.values().map(|sb| vec![*sb]).collect_vec();
             record.push_format_string(b"SB", &sb)?;

--- a/src/grammar/formula.rs
+++ b/src/grammar/formula.rs
@@ -1180,7 +1180,7 @@ impl VAFRange {
     }
 
     pub(crate) fn observable_min(&self, n_obs: usize) -> AlleleFreq {
-        let min_vaf = if n_obs < 10 {
+        let min_vaf = if n_obs < 10 || !self.is_adjustment_possible(n_obs) {
             self.start
         } else {
             let obs_count = Self::expected_observation_count(self.start, n_obs);
@@ -1216,7 +1216,7 @@ impl VAFRange {
             *self.end != 0.0,
             "bug: observable_max may not be called if end=0.0."
         );
-        if n_obs < 10 {
+        if n_obs < 10 || !self.is_adjustment_possible(n_obs) {
             self.end
         } else {
             let mut obs_count = Self::expected_observation_count(self.end, n_obs);
@@ -1235,6 +1235,10 @@ impl VAFRange {
 
     fn expected_observation_count(freq: AlleleFreq, n_obs: usize) -> f64 {
         n_obs as f64 * *freq
+    }
+
+    fn is_adjustment_possible(&self, n_obs: usize) -> bool {
+        Self::expected_observation_count(self.end - self.start, n_obs) > 1.0
     }
 }
 

--- a/src/variants/evidence/realignment/edit_distance.rs
+++ b/src/variants/evidence/realignment/edit_distance.rs
@@ -442,7 +442,7 @@ impl EditDistanceCalculation {
             }
             // add the remaining sequence
             allele.extend(
-                (pos_ref..emission_params.ref_end() - emission_params.ref_offset() + 1)
+                (pos_ref..emission_params.ref_end() - emission_params.ref_offset())
                     .map(|i| emission_params.ref_base(i)),
             );
 

--- a/src/variants/evidence/realignment/mod.rs
+++ b/src/variants/evidence/realignment/mod.rs
@@ -39,6 +39,7 @@ use self::edit_distance::EditDistance;
 use self::pairhmm::RefBaseEmission;
 use self::pairhmm::{ReadVsAlleleEmission, RefBaseVariantEmission};
 
+#[derive(Debug)]
 pub(crate) struct CandidateRegion {
     overlap: bool,
     read_interval: Range<usize>,

--- a/src/variants/model/modes/generic.rs
+++ b/src/variants/model/modes/generic.rs
@@ -296,13 +296,14 @@ impl GenericPosterior {
                         let resolution = &self.resolutions[*sample];
                         let min_vaf = vafs.observable_min(n_obs);
                         let max_vaf = vafs.observable_max(n_obs);
+                        assert!(min_vaf <= max_vaf, "bug: min_vaf > max_vaf");
                         let mut density = |vaf| {
                             let mut likelihood_operands = likelihood_operands.clone();
                             push_base_event(vaf, &mut likelihood_operands, false);
                             subdensity(&mut likelihood_operands)
                         };
 
-                        if (max_vaf - min_vaf) < **resolution {
+                        let p = if (max_vaf - min_vaf) < **resolution {
                             // METHOD: Interval too small for desired resolution.
                             // Just use 3 grid points.
                             LogProb::ln_simpsons_integrate_exp(
@@ -329,7 +330,9 @@ impl GenericPosterior {
                                 max_vaf,
                                 **resolution,
                             )
-                        }
+                        };
+
+                        p
                     }
                 }
             }


### PR DESCRIPTION
### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
