### PR TITLE
refactor: Make collect_variants public

### DIFF
--- a/src/utils/collect_variants.rs
+++ b/src/utils/collect_variants.rs
@@ -35,7 +35,7 @@ pub(crate) struct VariantInfo {
 }
 
 /// Collect variants from a given ´bcf::Record`.
-pub(crate) fn collect_variants(
+pub fn collect_variants(
     record: &mut bcf::Record,
     skip_imprecise: bool,
     skips: Option<&mut SimpleCounter<SkipReason>>,


### PR DESCRIPTION
This PR makes the `collect_variants` function public for reuse in another crate.