### PR TITLE
fix: fix decompression of CRAM files that rely on an external reference FASTA. Varlociraptor now uses the given reference FASTA for this decompression

### DIFF
--- a/src/calling/variants/preprocessing/mod.rs
+++ b/src/calling/variants/preprocessing/mod.rs
@@ -202,6 +202,13 @@ impl<R: realignment::Realigner + Clone + std::marker::Send + std::marker::Sync>
         let mut bam_reader =
             bam::IndexedReader::from_path(&self.inbam).context("Unable to read BAM/CRAM file.")?;
         bam_reader.set_threads(1)?;
+        bam_reader
+            .set_reference(
+                self.reference_buffer.reference_path().expect(
+                    "bug: reference buffer seemingly has not been created from reference file",
+                ),
+            )
+            .context("Unable to read reference FASTA")?;
 
         let mut sample = SampleBuilder::default()
             .max_depth(self.max_depth)


### PR DESCRIPTION
Fixes #416.

### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
