### PR TITLE
refactor: rename evidences so that they are distinguishable from other technologies

### DIFF
--- a/src/variants/types/breakends.rs
+++ b/src/variants/types/breakends.rs
@@ -271,7 +271,7 @@ impl<R: Realigner> BreakendGroup<R> {
         };
 
         match evidence {
-            Evidence::PairedEnd { left, right } => {
+            Evidence::PairedEndSequencingRead { left, right } => {
                 assert_eq!(self.breakends.len(), 2);
                 for bnds in self.breakends.values().permutations(2) {
                     let (bnd, other_bnd) = (bnds[0], bnds[1]);
@@ -295,7 +295,7 @@ impl<R: Realigner> BreakendGroup<R> {
                 }
                 None
             }
-            Evidence::SingleEnd(_) => None,
+            Evidence::SingleEndSequencingRead(_) => None,
         }
     }
 }
@@ -343,7 +343,7 @@ impl<R: Realigner> Variant for BreakendGroup<R> {
             };
 
             let overlapping: Vec<_> = match evidence {
-                Evidence::SingleEnd(read) => {
+                Evidence::SingleEndSequencingRead(read) => {
                     if !is_valid_ref_bases(read) {
                         return None;
                     }
@@ -359,7 +359,7 @@ impl<R: Realigner> Variant for BreakendGroup<R> {
                         })
                         .collect()
                 }
-                Evidence::PairedEnd { left, right } => {
+                Evidence::PairedEndSequencingRead { left, right } => {
                     if !is_valid_ref_bases(left) && !is_valid_ref_bases(right) {
                         return None;
                     }
@@ -402,7 +402,7 @@ impl<R: Realigner> Variant for BreakendGroup<R> {
             if let Some(classification) = self.classify_imprecise_evidence(evidence) {
                 if self.is_deletion() {
                     match evidence {
-                        Evidence::PairedEnd { left, right } => {
+                        Evidence::PairedEndSequencingRead { left, right } => {
                             if let Some((left_bnd, right_bnd)) = self.breakend_pair() {
                                 // METHOD: we consider all possible lengths of the deletion,
                                 // use a uniform prior and sum up the joint probabilities for the alt allele.
@@ -447,7 +447,7 @@ impl<R: Realigner> Variant for BreakendGroup<R> {
                                 )
                             }
                         }
-                        Evidence::SingleEnd(_) => unreachable!(
+                        Evidence::SingleEndSequencingRead(_) => unreachable!(
                             "bug: single end reads cannot be used as evidence for \
                              imprecise breakend groups"
                         ),
@@ -485,7 +485,7 @@ impl<R: Realigner> Variant for BreakendGroup<R> {
             }
         } else {
             match evidence {
-                Evidence::SingleEnd(record) => {
+                Evidence::SingleEndSequencingRead(record) => {
                     Ok(Some(self.realigner.borrow_mut().allele_support(
                         record,
                         self.loci.iter(),
@@ -494,7 +494,7 @@ impl<R: Realigner> Variant for BreakendGroup<R> {
                         alignment_properties,
                     )?))
                 }
-                Evidence::PairedEnd { left, right } => {
+                Evidence::PairedEndSequencingRead { left, right } => {
                     let left_support = self.realigner.borrow_mut().allele_support(
                         left,
                         self.loci.iter(),
@@ -532,7 +532,7 @@ impl<R: Realigner> Variant for BreakendGroup<R> {
             LogProb::ln_one()
         } else {
             match evidence {
-                Evidence::PairedEnd { left, right } => {
+                Evidence::PairedEndSequencingRead { left, right } => {
                     // METHOD: we do not require the fragment to enclose the breakend group.
                     // Hence, we treat both reads independently.
                     (self
@@ -543,7 +543,7 @@ impl<R: Realigner> Variant for BreakendGroup<R> {
                             .ln_one_minus_exp())
                     .ln_one_minus_exp()
                 }
-                Evidence::SingleEnd(read) => {
+                Evidence::SingleEndSequencingRead(read) => {
                     self.prob_sample_alt_read(read.seq().len() as u64, alignment_properties)
                 }
             }

--- a/src/variants/types/insertion.rs
+++ b/src/variants/types/insertion.rs
@@ -142,8 +142,8 @@ impl<R: Realigner> Variant for Insertion<R> {
         _: &AlignmentProperties,
     ) -> Option<Vec<usize>> {
         if match evidence {
-            Evidence::SingleEnd(read) => !self.locus().overlap(read, true).is_none(),
-            Evidence::PairedEnd { left, right } => {
+            Evidence::SingleEndSequencingRead(read) => !self.locus().overlap(read, true).is_none(),
+            Evidence::PairedEndSequencingRead { left, right } => {
                 !self.locus().overlap(left, true).is_none()
                     || !self.locus().overlap(right, true).is_none()
             }
@@ -167,14 +167,16 @@ impl<R: Realigner> Variant for Insertion<R> {
         alt_variants: &[Box<dyn Realignable>],
     ) -> Result<Option<AlleleSupport>> {
         match evidence {
-            Evidence::SingleEnd(record) => Ok(Some(self.realigner.borrow_mut().allele_support(
-                record,
-                self.locus.iter(),
-                self,
-                alt_variants,
-                alignment_properties,
-            )?)),
-            Evidence::PairedEnd { left, right } => {
+            Evidence::SingleEndSequencingRead(record) => {
+                Ok(Some(self.realigner.borrow_mut().allele_support(
+                    record,
+                    self.locus.iter(),
+                    self,
+                    alt_variants,
+                    alignment_properties,
+                )?))
+            }
+            Evidence::PairedEndSequencingRead { left, right } => {
                 let left_support = self.realigner.borrow_mut().allele_support(
                     left,
                     self.locus.iter(),
@@ -205,7 +207,7 @@ impl<R: Realigner> Variant for Insertion<R> {
         alignment_properties: &AlignmentProperties,
     ) -> LogProb {
         match evidence {
-            Evidence::PairedEnd { left, right } => {
+            Evidence::PairedEndSequencingRead { left, right } => {
                 // METHOD: we do not require the fragment to enclose the variant.
                 // Hence, we treat both reads independently.
                 (self
@@ -216,7 +218,7 @@ impl<R: Realigner> Variant for Insertion<R> {
                         .ln_one_minus_exp())
                 .ln_one_minus_exp()
             }
-            Evidence::SingleEnd(read) => {
+            Evidence::SingleEndSequencingRead(read) => {
                 self.prob_sample_alt_read(read.seq().len() as u64, alignment_properties)
             }
         }

--- a/src/variants/types/mnv.rs
+++ b/src/variants/types/mnv.rs
@@ -241,14 +241,14 @@ impl<R: Realigner> Variant for Mnv<R> {
         _: &AlignmentProperties,
     ) -> Option<Vec<usize>> {
         match evidence {
-            Evidence::SingleEnd(read) => {
+            Evidence::SingleEndSequencingRead(read) => {
                 if let Overlap::Enclosing = self.locus().overlap(read, false) {
                     Some(vec![0])
                 } else {
                     None
                 }
             }
-            Evidence::PairedEnd { left, right } => {
+            Evidence::PairedEndSequencingRead { left, right } => {
                 if let Overlap::Enclosing = self.locus().overlap(left, false) {
                     Some(vec![0])
                 } else if let Overlap::Enclosing = self.locus().overlap(right, false) {
@@ -271,10 +271,10 @@ impl<R: Realigner> Variant for Mnv<R> {
         alt_variants: &[Box<dyn Realignable>],
     ) -> Result<Option<AlleleSupport>> {
         match evidence {
-            Evidence::SingleEnd(read) => {
+            Evidence::SingleEndSequencingRead(read) => {
                 Ok(self.allele_support_per_read(read, alignment_properties, alt_variants)?)
             }
-            Evidence::PairedEnd { left, right } => {
+            Evidence::PairedEndSequencingRead { left, right } => {
                 let left_support =
                     self.allele_support_per_read(left, alignment_properties, alt_variants)?;
                 let right_support =

--- a/src/variants/types/none.rs
+++ b/src/variants/types/none.rs
@@ -97,14 +97,14 @@ impl Variant for None {
         _: &AlignmentProperties,
     ) -> Option<Vec<usize>> {
         match evidence {
-            Evidence::SingleEnd(read) => {
+            Evidence::SingleEndSequencingRead(read) => {
                 if let Overlap::Enclosing = self.locus().overlap(read, false) {
                     Some(vec![0])
                 } else {
                     None
                 }
             }
-            Evidence::PairedEnd { left, right } => {
+            Evidence::PairedEndSequencingRead { left, right } => {
                 if let Overlap::Enclosing = self.locus().overlap(left, false) {
                     Some(vec![0])
                 } else if let Overlap::Enclosing = self.locus().overlap(right, false) {
@@ -127,8 +127,8 @@ impl Variant for None {
         _: &[Box<dyn Realignable>],
     ) -> Result<Option<AlleleSupport>> {
         match evidence {
-            Evidence::SingleEnd(read) => Ok(self.allele_support_per_read(read)?),
-            Evidence::PairedEnd { left, right } => {
+            Evidence::SingleEndSequencingRead(read) => Ok(self.allele_support_per_read(read)?),
+            Evidence::PairedEndSequencingRead { left, right } => {
                 let left_support = self.allele_support_per_read(left)?;
                 let right_support = self.allele_support_per_read(right)?;
 

--- a/src/variants/types/replacement.rs
+++ b/src/variants/types/replacement.rs
@@ -157,8 +157,8 @@ impl<R: Realigner> Variant for Replacement<R> {
         _: &AlignmentProperties,
     ) -> Option<Vec<usize>> {
         if match evidence {
-            Evidence::SingleEnd(read) => !self.locus().overlap(read, true).is_none(),
-            Evidence::PairedEnd { left, right } => {
+            Evidence::SingleEndSequencingRead(read) => !self.locus().overlap(read, true).is_none(),
+            Evidence::PairedEndSequencingRead { left, right } => {
                 !self.locus().overlap(left, true).is_none()
                     || !self.locus().overlap(right, true).is_none()
             }
@@ -182,14 +182,16 @@ impl<R: Realigner> Variant for Replacement<R> {
         alt_variants: &[Box<dyn Realignable>],
     ) -> Result<Option<AlleleSupport>> {
         match evidence {
-            Evidence::SingleEnd(record) => Ok(Some(self.realigner.borrow_mut().allele_support(
-                record,
-                self.loci.iter(),
-                self,
-                alt_variants,
-                alignment_properties,
-            )?)),
-            Evidence::PairedEnd { left, right } => {
+            Evidence::SingleEndSequencingRead(record) => {
+                Ok(Some(self.realigner.borrow_mut().allele_support(
+                    record,
+                    self.loci.iter(),
+                    self,
+                    alt_variants,
+                    alignment_properties,
+                )?))
+            }
+            Evidence::PairedEndSequencingRead { left, right } => {
                 let left_support = self.realigner.borrow_mut().allele_support(
                     left,
                     self.loci.iter(),
@@ -220,7 +222,7 @@ impl<R: Realigner> Variant for Replacement<R> {
         alignment_properties: &AlignmentProperties,
     ) -> LogProb {
         match evidence {
-            Evidence::PairedEnd { left, right } => {
+            Evidence::PairedEndSequencingRead { left, right } => {
                 // METHOD: we do not require the fragment to enclose the variant.
                 // Hence, we treat both reads independently.
                 (self
@@ -231,7 +233,7 @@ impl<R: Realigner> Variant for Replacement<R> {
                         .ln_one_minus_exp())
                 .ln_one_minus_exp()
             }
-            Evidence::SingleEnd(read) => {
+            Evidence::SingleEndSequencingRead(read) => {
                 self.prob_sample_alt_read(read.seq().len() as u64, alignment_properties)
             }
         }

--- a/src/variants/types/snv.rs
+++ b/src/variants/types/snv.rs
@@ -184,14 +184,14 @@ impl<R: Realigner> Variant for Snv<R> {
         _: &AlignmentProperties,
     ) -> Option<Vec<usize>> {
         match evidence {
-            Evidence::SingleEnd(read) => {
+            Evidence::SingleEndSequencingRead(read) => {
                 if let Overlap::Enclosing = self.locus().overlap(read, false) {
                     Some(vec![0])
                 } else {
                     None
                 }
             }
-            Evidence::PairedEnd { left, right } => {
+            Evidence::PairedEndSequencingRead { left, right } => {
                 if let Overlap::Enclosing = self.locus().overlap(left, false) {
                     Some(vec![0])
                 } else if let Overlap::Enclosing = self.locus().overlap(right, false) {
@@ -214,10 +214,10 @@ impl<R: Realigner> Variant for Snv<R> {
         alt_variants: &[Box<dyn Realignable>],
     ) -> Result<Option<AlleleSupport>> {
         match evidence {
-            Evidence::SingleEnd(read) => {
+            Evidence::SingleEndSequencingRead(read) => {
                 Ok(self.allele_support_per_read(read, alignment_properties, alt_variants)?)
             }
-            Evidence::PairedEnd { left, right } => {
+            Evidence::PairedEndSequencingRead { left, right } => {
                 let left_support =
                     self.allele_support_per_read(left, alignment_properties, alt_variants)?;
                 let right_support =


### PR DESCRIPTION


### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced clarity in evidence types by renaming variants to explicitly indicate their relation to sequencing reads (e.g., `SingleEnd` to `SingleEndSequencingRead`).
  
- **Bug Fixes**
	- Improved semantic understanding of evidence processing without altering existing functionality. 

- **Documentation**
	- Updated naming conventions across multiple implementations to reflect the new descriptive terms, aiding future developers in understanding the code better.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->