### PR TITLE
fix: testcase subcommand - breakend support

### DIFF
--- a/src/testcase/builder.rs
+++ b/src/testcase/builder.rs
@@ -457,11 +457,12 @@ impl Testcase {
             candidate_record.set_pos(candidate_record.pos() - ref_start as i64);
             let mod_alleles =
                 modify_bnd_alleles(&candidate_record.alleles(), &extended_chromosomal_regions)?;
-            let bla = mod_alleles
-                .iter()
-                .map(|inner_vec| inner_vec.as_slice())
-                .collect_vec();
-            candidate_record.set_alleles(&bla)?;
+            candidate_record.set_alleles(
+                &mod_alleles
+                    .iter()
+                    .map(|inner_vec| inner_vec.as_slice())
+                    .collect_vec(),
+            )?;
             if let Ok(Some(end)) = candidate_record
                 .info(b"END")
                 .integer()

--- a/src/testcase/builder.rs
+++ b/src/testcase/builder.rs
@@ -12,15 +12,17 @@ use bio::io::fasta;
 use bio_types::genome::AbstractLocus;
 use derive_builder::Builder;
 use regex::Regex;
-use rust_htslib::bam::Read as BamRead;
+use rgsl::util;
+use rust_htslib::bam::{record, Read as BamRead};
 use rust_htslib::{bam, bcf, bcf::Read};
 
 use crate::calling::variants::preprocessing::haplotype_feature_index::HaplotypeFeatureIndex;
-use crate::errors;
 use crate::utils;
 use crate::utils::anonymize::Anonymizer;
+use crate::utils::collect_variants::VariantInfo;
 use crate::variants::model::{HaplotypeIdentifier, Variant};
 use crate::variants::sample;
+use crate::{candidates, errors};
 use crate::{cli, reference};
 
 lazy_static! {
@@ -39,7 +41,7 @@ struct TestcaseTemplate {
     purity: Option<f64>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct Sample {
     path: String,
     properties: String,
@@ -235,48 +237,11 @@ impl Testcase {
         }
     }
 
-    pub(crate) fn write(&mut self) -> Result<()> {
-        let mut anonymizer = Anonymizer::new();
-
-        fs::create_dir_all(&self.prefix)?;
-
-        let candidate_filename = Path::new("candidates.vcf");
-        let mut skips = utils::SimpleCounter::default();
-
-        // get and write candidate
-        let mut candidate = None;
-        for (i, mut record) in (self.variants()?).into_iter().enumerate() {
-            let variants = utils::collect_variants(&mut record, false, Some(&mut skips))?;
-            for variant in variants {
-                if i == self.idx {
-                    // if no chromosome was specified, we infer the locus from the matching
-                    // variant
-                    if self.chrom_name.is_none() {
-                        self.chrom_name = Some(
-                            self.candidate_reader()?
-                                .header()
-                                .rid2name(record.rid().unwrap())
-                                .unwrap()
-                                .to_owned(),
-                        );
-                        self.pos = Some(record.pos() as u64);
-                    }
-
-                    candidate = Some((variant, record));
-
-                    break;
-                }
-            }
-        }
-        if candidate.is_none() {
-            return Err(errors::Error::InvalidIndex.into());
-        }
-        let (candidate_variant_info, mut candidate_record) = candidate.unwrap();
-
-        let chrom_name = self.chrom_name.as_ref().unwrap();
-        let pos = self.pos.unwrap();
-        let ref_name = str::from_utf8(chrom_name)?;
-
+    pub(crate) fn collect_start_end(
+        &mut self,
+        candidate_variant_info: VariantInfo,
+        pos: u64,
+    ) -> Result<(u64, u64)> {
         let (start, end) = match candidate_variant_info.variant() {
             Variant::Deletion(l) => (pos.saturating_sub(1000), pos + *l as u64 + 1000),
             Variant::Insertion(ref seq) => {
@@ -295,25 +260,49 @@ impl Testcase {
             ),
             Variant::None => (pos.saturating_sub(100), pos + 1 + 100),
         };
+        Ok((start, end))
+    }
 
-        let mut ref_start = start;
-        let mut ref_end = end;
-        // first pass, extend reference interval
-        for path in self.bams.values() {
-            let mut bam_reader = bam::IndexedReader::from_path(path)?;
+    pub(crate) fn write(&mut self) -> Result<()> {
+        let mut anonymizer = Anonymizer::new();
 
-            let tid = bam_reader.header().tid(chrom_name).unwrap();
-            bam_reader.fetch((tid, start, end))?;
-            for res in bam_reader.records() {
-                let rec = res?;
-                let seq_len = rec.seq().len() as u64;
-                ref_start = cmp::min((rec.pos() as u64).saturating_sub(seq_len), ref_start);
-                ref_end = cmp::max(rec.cigar().end_pos() as u64 + seq_len, ref_end);
+        fs::create_dir_all(&self.prefix)?;
+
+        let candidate_filename = Path::new("candidates.vcf");
+        let mut skips = utils::SimpleCounter::default();
+
+        // get all candidates
+        let mut candidates = Vec::new();
+        for mut record in self.variants()? {
+            let variants = utils::collect_variants(&mut record, false, Some(&mut skips))?;
+            for variant in variants {
+                candidates.push((variant, record.clone()))
             }
         }
+        // get start and end (min, max all start and end pos per chromosome)
+        let mut chromosomal_regions: HashMap<Vec<u8>, (u64, u64)> = HashMap::new();
+        for (candidate_variant_info, candidate_record) in candidates.clone() {
+            let chrom = self
+                .candidate_reader()?
+                .header()
+                .rid2name(candidate_record.rid().unwrap())
+                .unwrap()
+                .to_owned();
+            let rec_pos = candidate_record.pos() as u64;
+            let (candidate_start, candidate_end) =
+                self.collect_start_end(candidate_variant_info, rec_pos)?;
+            chromosomal_regions
+                .entry(chrom)
+                .and_modify(|e| {
+                    e.0 = e.0.min(candidate_start);
+                    e.1 = e.1.max(candidate_end);
+                })
+                .or_insert((candidate_start, candidate_end));
+        }
 
-        // second pass, write samples
+        // write samples
         let mut samples = HashMap::new();
+        let mut extended_chromosomal_regions = HashMap::new();
         for (name, path) in &self.bams {
             let properties = sample::estimate_alignment_properties(
                 path,
@@ -323,6 +312,7 @@ impl Testcase {
                 0.,
             )?;
             let mut bam_reader = bam::IndexedReader::from_path(path)?;
+
             let filename = Path::new(name).with_extension("bam");
 
             let header = bam::header::Header::from_template(bam_reader.header());
@@ -338,31 +328,45 @@ impl Testcase {
             let mut bam_writer =
                 bam::Writer::from_path(self.prefix.join(&filename), &header, bam::Format::Bam)?;
 
-            let tid = bam_reader.header().tid(chrom_name).unwrap();
+            // extend reference interval by bam records
+            for (chrom_name, (start, end)) in chromosomal_regions.clone() {
+                let mut ref_start = start;
+                let mut ref_end = end;
+                let tid: u32 = bam_reader.header().tid(&chrom_name).unwrap();
+                // first pass, extend reference interval
+                bam_reader.fetch((tid, start, end))?;
+                for res in bam_reader.records() {
+                    let rec = res?;
+                    let seq_len = rec.seq().len() as u64;
+                    ref_start = cmp::min((rec.pos() as u64).saturating_sub(seq_len), ref_start);
+                    ref_end = cmp::max(rec.cigar().end_pos() as u64 + seq_len, ref_end);
+                }
+                extended_chromosomal_regions.insert(chrom_name.clone(), (ref_start, ref_end));
 
-            bam_reader.fetch((tid, start, end))?;
-            for res in bam_reader.records() {
-                let mut rec = res?;
-                // update mapping position to interval
-                rec.set_pos(rec.pos() - ref_start as i64);
-                rec.set_mpos(rec.mpos() - ref_start as i64);
-                rec.set_tid(bam_writer.header().tid(chrom_name).unwrap() as i32);
-                if rec.remove_aux(b"RG").is_err() {
-                    debug!("No RG tag to remove in BAM record.");
+                bam_reader.fetch((tid, start, end))?;
+                for res in bam_reader.records() {
+                    let mut rec = res?;
+                    // update mapping position to interval
+                    rec.set_pos(rec.pos() - ref_start as i64);
+                    rec.set_mpos(rec.mpos() - ref_start as i64);
+                    rec.set_tid(bam_writer.header().tid(&chrom_name).unwrap() as i32);
+                    if rec.remove_aux(b"RG").is_err() {
+                        debug!("No RG tag to remove in BAM record.");
+                    }
+                    if self.anonymize {
+                        anonymizer.anonymize_bam_record(&mut rec);
+                    }
+                    bam_writer.write(&rec)?;
                 }
-                if self.anonymize {
-                    anonymizer.anonymize_bam_record(&mut rec);
-                }
-                bam_writer.write(&rec)?;
+                samples.insert(
+                    name.to_owned(),
+                    Sample {
+                        path: filename.to_str().unwrap().to_owned(),
+                        properties: serde_json::to_string(&properties)?,
+                        options: self.options.get(name).unwrap().to_owned(),
+                    },
+                );
             }
-            samples.insert(
-                name.to_owned(),
-                Sample {
-                    path: filename.to_str().unwrap().to_owned(),
-                    properties: serde_json::to_string(&properties)?,
-                    options: self.options.get(name).unwrap().to_owned(),
-                },
-            );
         }
 
         // write candidate
@@ -376,18 +380,6 @@ impl Testcase {
             true,
             bcf::Format::Vcf,
         )?;
-        candidate_record.set_pos(candidate_record.pos() - ref_start as i64);
-        if let Ok(Some(end)) = candidate_record
-            .info(b"END")
-            .integer()
-            .map(|v| v.map(|v| v[0]))
-        {
-            candidate_record.push_info_integer(b"END", &[end - ref_start as i32])?;
-        }
-        if self.anonymize {
-            anonymizer.anonymize_bcf_record(&mut candidate_record)?;
-        }
-        candidate_writer.write(&candidate_record)?;
 
         // write scenario
         let scenario = if let Some(scenario) = self.scenario.as_ref() {
@@ -397,39 +389,65 @@ impl Testcase {
             None
         };
 
-        // fetch reference
-        // limit ref_end
-        for seq in self.reference_buffer.sequences() {
-            if seq.name == ref_name {
-                ref_end = cmp::min(ref_end, seq.len);
-            }
-        }
-
-        let mut ref_seq =
-            self.reference_buffer.seq(ref_name)?[ref_start as usize..ref_end as usize].to_owned();
-
-        if self.anonymize {
-            anonymizer.anonymize_seq(&mut ref_seq);
-        }
-
-        // write reference
         let ref_filename = "ref.fa";
         let mut ref_writer = fasta::Writer::to_file(self.prefix.join(ref_filename))?;
-        ref_writer.write(ref_name, None, &ref_seq)?;
-
-        let mut desc = File::create(self.prefix.join("testcase.yaml"))?;
-        desc.write_all(
-            TestcaseTemplate {
-                samples,
-                candidate: candidate_filename.to_str().unwrap().to_owned(),
-                ref_path: ref_filename.to_owned(),
-                scenario,
-                mode: self.mode,
-                purity: self.purity,
+        for (_, mut candidate_record) in candidates {
+            let chrom = self
+                .candidate_reader()?
+                .header()
+                .rid2name(candidate_record.rid().unwrap())
+                .unwrap()
+                .to_owned();
+            let (ref_start, mut ref_end) =
+                extended_chromosomal_regions.get(&chrom).unwrap().to_owned();
+            candidate_record.set_pos(candidate_record.pos() - ref_start as i64);
+            if let Ok(Some(end)) = candidate_record
+                .info(b"END")
+                .integer()
+                .map(|v| v.map(|v| v[0]))
+            {
+                candidate_record.push_info_integer(b"END", &[end - ref_start as i32])?;
             }
-            .render()?
-            .as_bytes(),
-        )?;
+            if self.anonymize {
+                anonymizer.anonymize_bcf_record(&mut candidate_record)?;
+            }
+            candidate_writer.write(&candidate_record)?;
+
+            // fetch reference
+            // limit ref_end
+            let ref_name = str::from_utf8(&chrom)?;
+            for seq in self.reference_buffer.sequences() {
+                if seq.name == ref_name {
+                    ref_end = cmp::min(ref_end, seq.len);
+                }
+            }
+
+            let mut ref_seq = self.reference_buffer.seq(ref_name)?
+                [ref_start as usize..ref_end as usize]
+                .to_owned();
+
+            if self.anonymize {
+                anonymizer.anonymize_seq(&mut ref_seq);
+            }
+
+            // write reference
+
+            ref_writer.write(ref_name, None, &ref_seq)?;
+
+            let mut desc = File::create(self.prefix.join("testcase.yaml"))?;
+            desc.write_all(
+                TestcaseTemplate {
+                    samples: samples.clone(),
+                    candidate: candidate_filename.to_str().unwrap().to_owned(),
+                    ref_path: ref_filename.to_owned(),
+                    scenario: scenario.clone(),
+                    mode: self.mode,
+                    purity: self.purity,
+                }
+                .render()?
+                .as_bytes(),
+            )?;
+        }
 
         Ok(())
     }


### PR DESCRIPTION
### Description

In its current state `varlociraptor testcase` does not correctly support breakend variants. This means that a mate candidate record of a breakend variant is not considered. Further, only the first candidate record is taken into acount for testcase creation.

Changes:

- adding all candidates variants (and their mates) to `candidate.vcf`
- adding test references for variant records on different chromosomes to `ref.fa`
- properly adjust the offset of a mate position (`mpos`) for bam records where the mate is on a different chromosome
- correctly annotate the position in alt alleles of vcf records in case of breakends e.g: `A[4:46453234[`

These changes require multiple looping over input bam and vcf-records for preprocessing information like positional offsets before being able to modify and write vcf- and bam-records.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new function to modify genomic alleles based on chromosomal regions.
	- Updated the `Sample` struct to support easier duplication.

- **Improvements**
	- Enhanced logic for processing candidate variants and chromosomal regions.
	- Improved handling of reference sequences to ensure accuracy based on sequence length.
	- Updated rendering of the `TestcaseTemplate` for better data representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->