### PR TITLE
refactor: generalize evidence name into ids that can as well be u32

### DIFF
--- a/src/variants/evidence/observations/fragment_id_factory.rs
+++ b/src/variants/evidence/observations/fragment_id_factory.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 
-use super::read_observation::Evidence;
+use super::read_observation::{Evidence, EvidenceIdentifier};
 
 #[derive(Default, Debug)]
 pub(crate) struct FragmentIdFactory {
-    ids: HashMap<Vec<u8>, u64>,
+    ids: HashMap<EvidenceIdentifier, u64>,
     next_id: u64,
     current_contig: String,
 }
@@ -18,11 +18,11 @@ impl FragmentIdFactory {
         }
     }
     pub(crate) fn register(&mut self, evidence: &Evidence) -> u64 {
-        if self.ids.contains_key(evidence.name()) {
-            *self.ids.get(evidence.name()).unwrap()
+        if self.ids.contains_key(&evidence.id()) {
+            *self.ids.get(&evidence.id()).unwrap()
         } else {
             let id = self.next_id;
-            self.ids.insert(evidence.name().to_vec(), id);
+            self.ids.insert(evidence.id(), id);
             self.next_id += 1;
             id
         }

--- a/src/variants/evidence/observations/read_observation.rs
+++ b/src/variants/evidence/observations/read_observation.rs
@@ -766,11 +766,11 @@ pub(crate) enum EvidenceIdentifier {
     Integer(u32),
 }
 
-impl ToString for EvidenceIdentifier {
-    fn to_string(&self) -> String {
+impl std::fmt::Display for EvidenceIdentifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            EvidenceIdentifier::Bytes(id) => String::from_utf8_lossy(id).to_string(),
-            EvidenceIdentifier::Integer(id) => id.to_string(),
+            EvidenceIdentifier::Bytes(id) => write!(f, "{}", str::from_utf8(id).unwrap()),
+            EvidenceIdentifier::Integer(id) => write!(f, "{}", id),
         }
     }
 }

--- a/src/variants/evidence/observations/read_observation.rs
+++ b/src/variants/evidence/observations/read_observation.rs
@@ -594,7 +594,7 @@ pub(crate) trait Observable: Variant {
                     let alt_indel_len = allele_support.homopolymer_indel_len().unwrap_or(0);
 
                     let mut obs = ReadObservationBuilder::default();
-                    obs.name(Some(str::from_utf8(evidence.name()).unwrap().to_owned()))
+                    obs.name(Some(evidence.id().to_string().to_owned()))
                         .fragment_id(id)
                         .prob_mapping_mismapping(self.prob_mapping(evidence))
                         .prob_alt(allele_support.prob_alt_allele())
@@ -713,10 +713,14 @@ impl Evidence {
         }
     }
 
-    pub(crate) fn name(&self) -> &[u8] {
+    pub(crate) fn id(&self) -> EvidenceIdentifier {
         match self {
-            Evidence::PairedEndSequencingRead { left, .. } => left.qname(),
-            Evidence::SingleEndSequencingRead(rec) => rec.qname(),
+            Evidence::PairedEndSequencingRead { left, .. } => {
+                EvidenceIdentifier::Bytes(left.qname().to_owned())
+            }
+            Evidence::SingleEndSequencingRead(rec) => {
+                EvidenceIdentifier::Bytes(rec.qname().to_owned())
+            }
         }
     }
 
@@ -752,6 +756,30 @@ impl Hash for Evidence {
         match self {
             Evidence::SingleEndSequencingRead(a) => a.qname().hash(state),
             Evidence::PairedEndSequencingRead { left: a, .. } => a.qname().hash(state),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) enum EvidenceIdentifier {
+    Bytes(Vec<u8>),
+    Integer(u32),
+}
+
+impl ToString for EvidenceIdentifier {
+    fn to_string(&self) -> String {
+        match self {
+            EvidenceIdentifier::Bytes(id) => String::from_utf8_lossy(id).to_string(),
+            EvidenceIdentifier::Integer(id) => id.to_string(),
+        }
+    }
+}
+
+impl Hash for EvidenceIdentifier {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            EvidenceIdentifier::Bytes(id) => id.hash(state),
+            EvidenceIdentifier::Integer(id) => id.hash(state),
         }
     }
 }


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `EvidenceIdentifier` enum for more flexible evidence identification.
	- Updated the `Evidence` struct to include an `id` method that returns the new identifier.
  
- **Bug Fixes**
	- Enhanced type-specific handling of evidence identifiers in the `FragmentIdFactory`.

- **Documentation**
	- Updated method signatures and added new functionalities for better clarity on evidence handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->