### PR TITLE
feat: optical mapping support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ dependencies = [
 [[package]]
 name = "bio"
 version = "2.0.3"
-source = "git+https://github.com/laurakuehle/rust-bio.git?branch=master#19fb4418096a5564e5565022b7975d2ea0536219"
+source = "git+https://github.com/laurakuehle/rust-bio.git?branch=master#ba9b43d87ec67d78b99407b66a9b62635beec21e"
 dependencies = [
  "anyhow",
  "approx",
@@ -239,7 +239,7 @@ dependencies = [
  "newtype_derive",
  "num-integer",
  "num-traits",
- "ordered-float 4.2.1",
+ "ordered-float 4.3.0",
  "petgraph",
  "rand 0.8.5",
  "regex",
@@ -1512,9 +1512,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "4.2.1"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ff2cf528c6c03d9ed653d6c4ce1dc0582dc4af309790ad92f07c1cd551b0be"
+checksum = "44d501f1a72f71d3c063a6bbc8f7271fa73aa09fe5d6283b6571e2ed176a2537"
 dependencies = [
  "num-traits",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ dependencies = [
 [[package]]
 name = "bio"
 version = "2.0.3"
-source = "git+https://github.com/laurakuehle/rust-bio.git?branch=master#ba9b43d87ec67d78b99407b66a9b62635beec21e"
+source = "git+https://github.com/laurakuehle/rust-bio.git?branch=master#d366a0d8d6e417bcb3b854984dc00007c1729e9c"
 dependencies = [
  "anyhow",
  "approx",

--- a/src/variants/evidence/observations/read_observation.rs
+++ b/src/variants/evidence/observations/read_observation.rs
@@ -663,7 +663,7 @@ pub(crate) trait Observable: Variant {
     }
 }
 
-#[derive(Clone, Eq, Debug)]
+#[derive(Clone, Debug)]
 pub(crate) enum Evidence {
     SingleEndSequencingRead(Rc<bam::Record>),
     PairedEndSequencingRead {

--- a/src/variants/evidence/observations/read_observation.rs
+++ b/src/variants/evidence/observations/read_observation.rs
@@ -780,6 +780,7 @@ impl Hash for Evidence {
         match self {
             Evidence::SingleEndSequencingRead(a) => a.qname().hash(state),
             Evidence::PairedEndSequencingRead { left: a, .. } => a.qname().hash(state),
+            Evidence::OpticalMappingRead { alignment: a, .. } => a.id().hash(state),
         }
     }
 }

--- a/src/variants/evidence/observations/read_observation.rs
+++ b/src/variants/evidence/observations/read_observation.rs
@@ -770,6 +770,10 @@ impl PartialEq for Evidence {
                 Evidence::PairedEndSequencingRead { left: a, .. },
                 Evidence::PairedEndSequencingRead { left: b, .. },
             ) => a.qname() == b.qname(),
+            (
+                Evidence::OpticalMappingRead { alignment: a, .. },
+                Evidence::OpticalMappingRead { alignment: b, .. },
+            ) => a.id() == b.id(),
             _ => false,
         }
     }

--- a/src/variants/evidence/observations/read_observation.rs
+++ b/src/variants/evidence/observations/read_observation.rs
@@ -164,6 +164,13 @@ pub struct ExactAltLoci {
     inner: Vec<genome::Locus>,
 }
 
+impl<'a> From<&'a xmap::Record> for ExactAltLoci {
+    fn from(record: &'a xmap::Record) -> Self {
+        ExactAltLoci::default()
+        // TODO: Check whether this info is available in XMAPs
+    }
+}
+
 impl<'a> From<&'a bam::Record> for ExactAltLoci {
     fn from(record: &'a bam::Record) -> Self {
         match record.aux(b"XA") {
@@ -745,6 +752,7 @@ impl Evidence {
                 left.inner.extend(ExactAltLoci::from(right.as_ref()).inner);
                 left
             }
+            Evidence::OpticalMappingRead { alignment: rec, .. } => ExactAltLoci::from(rec.as_ref()),
         }
     }
 }

--- a/src/variants/evidence/observations/read_observation.rs
+++ b/src/variants/evidence/observations/read_observation.rs
@@ -734,7 +734,7 @@ impl Evidence {
         match self {
             Evidence::SingleEndSequencingRead(rec) => rec.seq_len(),
             Evidence::PairedEndSequencingRead { left, right } => left.seq_len() + right.seq_len(),
-            Evidence::OpticalMappingRead { alignment: a, .. } => a.qry_len(),
+            Evidence::OpticalMappingRead { alignment: a, .. } => a.qry_len().round() as usize,
         }
     }
 

--- a/src/variants/evidence/observations/read_observation.rs
+++ b/src/variants/evidence/observations/read_observation.rs
@@ -10,6 +10,8 @@ use std::rc::Rc;
 use std::str;
 
 use anyhow::Result;
+use bio::io::om::bnx;
+use bio::io::om::xmap;
 use bio::stats::bayesian::bayes_factors::evidence::KassRaftery;
 use bio::stats::{LogProb, PHREDProb};
 use bio_types::genome::{self, AbstractLocus};
@@ -663,7 +665,10 @@ pub(crate) enum Evidence {
     },
     // TODO add a proper record type here that contains all info needed to assess
     // whether the optical mapping record supports the variant or the reference allele
-    OpticalMappingRead(...),
+    OpticalMappingRead {
+        read: Rc<bnx::Record>,
+        alignment: Rc<xmap::Record>,
+    },
 }
 
 impl Evidence {

--- a/src/variants/evidence/observations/read_observation.rs
+++ b/src/variants/evidence/observations/read_observation.rs
@@ -742,6 +742,8 @@ impl Evidence {
         match self {
             Evidence::PairedEndSequencingRead { left, .. } => left.qname(),
             Evidence::SingleEndSequencingRead(rec) => rec.qname(),
+            // TODO: Better solution?
+            Evidence::OpticalMappingRead { alignment: a, .. } => a.id().as_bytes(),
         }
     }
 

--- a/src/variants/evidence/observations/read_observation.rs
+++ b/src/variants/evidence/observations/read_observation.rs
@@ -734,6 +734,7 @@ impl Evidence {
         match self {
             Evidence::SingleEndSequencingRead(rec) => rec.seq_len(),
             Evidence::PairedEndSequencingRead { left, right } => left.seq_len() + right.seq_len(),
+            Evidence::OpticalMappingRead { alignment: a, .. } => a.qry_len(),
         }
     }
 

--- a/src/variants/evidence/observations/read_observation.rs
+++ b/src/variants/evidence/observations/read_observation.rs
@@ -700,7 +700,7 @@ impl Evidence {
                     read_orientation(left.as_ref())
                 }
             }
-            Evidence::OpticalMappingRead(_) => Ok(SequenceReadPairOrientation::None),
+            Evidence::OpticalMappingRead { .. } => Ok(SequenceReadPairOrientation::None),
         }
     }
 
@@ -708,7 +708,7 @@ impl Evidence {
         match self {
             Evidence::SingleEndSequencingRead(read) => read.is_paired(),
             Evidence::PairedEndSequencingRead { left, .. } => left.is_paired(),
-            Evidence::OpticalMappingRead(_) => false,
+            Evidence::OpticalMappingRead { .. } => false,
         }
     }
 
@@ -726,7 +726,7 @@ impl Evidence {
                     || cigar_right.leading_softclips() > 0
                     || cigar_right.trailing_softclips() > 0
             }
-            Evidence::OpticalMappingRead(_) => false,
+            Evidence::OpticalMappingRead { .. } => false,
         }
     }
 

--- a/src/variants/sample.rs
+++ b/src/variants/sample.rs
@@ -93,7 +93,7 @@ pub(crate) struct OpticalMappingRecordBuffer {
 }
 
 // TODO
-impl OpticalMappingRecordBuffer {todo!()}
+impl OpticalMappingRecordBuffer {}
 
 #[derive(Default, Derefable)]
 pub(crate) struct Fetches {

--- a/src/variants/sample.rs
+++ b/src/variants/sample.rs
@@ -83,17 +83,24 @@ impl SequencingRecordBuffer {
     }
 }
 
-// TODO: What is the meaning of the window here? Needed?
 #[derive(new, Getters, Debug)]
 pub(crate) struct OpticalMappingRecordBuffer {
     xmap: xmap::Container,
     bnx: bnx::Container,
-    #[getset(get = "pub")]
-    read_window: u64,
 }
 
 // TODO
-impl OpticalMappingRecordBuffer {}
+impl OpticalMappingRecordBuffer {
+    pub(crate) fn fetch(&mut self, interval: &genome::Interval) -> Result<()> {
+        self.xmap.fetch(
+            interval.contig().parse::<u32>()?,
+            interval.range().start,
+            interval.range().end,
+        )?;
+
+        Ok(())
+    }
+}
 
 #[derive(Default, Derefable)]
 pub(crate) struct Fetches {

--- a/src/variants/sample.rs
+++ b/src/variants/sample.rs
@@ -89,15 +89,20 @@ pub(crate) struct OpticalMappingRecordBuffer {
     bnx: bnx::Container,
 }
 
-// TODO
 impl OpticalMappingRecordBuffer {
-    pub(crate) fn fetch(&mut self, interval: &genome::Interval) ->
-    Result<impl Iterator<Item = &Rc<xmap::Record>>> {
+    pub(crate) fn fetch(
+        &self,
+        interval: &genome::Interval,
+    ) -> Result<impl Iterator<Item = &Rc<xmap::Record>>> {
         self.xmap.fetch(
             interval.contig().parse::<u32>()?,
             interval.range().start,
             interval.range().end,
         )
+    }
+
+    pub(crate) fn qry_record(&self, bnx_id: &u32) -> Result<&Rc<bnx::Record>> {
+        self.bnx.record(bnx_id.clone())
     }
 }
 

--- a/src/variants/sample.rs
+++ b/src/variants/sample.rs
@@ -9,6 +9,8 @@ use std::rc::Rc;
 use std::str;
 
 use anyhow::Result;
+use bio::io::om::bnx;
+use bio::io::om::xmap;
 use bio_types::{genome, genome::AbstractInterval};
 use derive_builder::Builder;
 use rand::distributions;
@@ -81,13 +83,17 @@ impl SequencingRecordBuffer {
     }
 }
 
-
+// TODO: What is the meaning of the window here? Needed?
+#[derive(new, Getters, Debug)]
 pub(crate) struct OpticalMappingRecordBuffer {
-
+    xmap: xmap::Container,
+    bnx: bnx::Container,
+    #[getset(get = "pub")]
+    read_window: u64,
 }
 
-impl OpticalMappingRecordBuffer {
-}
+// TODO
+impl OpticalMappingRecordBuffer {todo!()}
 
 #[derive(Default, Derefable)]
 pub(crate) struct Fetches {

--- a/src/variants/sample.rs
+++ b/src/variants/sample.rs
@@ -91,14 +91,13 @@ pub(crate) struct OpticalMappingRecordBuffer {
 
 // TODO
 impl OpticalMappingRecordBuffer {
-    pub(crate) fn fetch(&mut self, interval: &genome::Interval) -> Result<()> {
+    pub(crate) fn fetch(&mut self, interval: &genome::Interval) ->
+    Result<impl Iterator<Item = &Rc<xmap::Record>>> {
         self.xmap.fetch(
             interval.contig().parse::<u32>()?,
             interval.range().start,
             interval.range().end,
-        )?;
-
-        Ok(())
+        )
     }
 }
 

--- a/src/variants/types/breakends.rs
+++ b/src/variants/types/breakends.rs
@@ -296,6 +296,7 @@ impl<R: Realigner> BreakendGroup<R> {
                 None
             }
             Evidence::SingleEndSequencingRead(_) => None,
+            Evidence::OpticalMappingRead { .. } => todo!(),
         }
     }
 }
@@ -376,6 +377,7 @@ impl<R: Realigner> Variant for BreakendGroup<R> {
                         })
                         .collect()
                 }
+                Evidence::OpticalMappingRead { .. } => todo!(),
             };
 
             if overlapping.is_empty() {
@@ -451,6 +453,7 @@ impl<R: Realigner> Variant for BreakendGroup<R> {
                             "bug: single end reads cannot be used as evidence for \
                              imprecise breakend groups"
                         ),
+                        Evidence::OpticalMappingRead { .. } => todo!(),
                     }
                 }
 
@@ -516,6 +519,7 @@ impl<R: Realigner> Variant for BreakendGroup<R> {
 
                     Ok(Some(support))
                 }
+                Evidence::OpticalMappingRead { .. } => todo!(),
             }
         }
     }
@@ -546,6 +550,7 @@ impl<R: Realigner> Variant for BreakendGroup<R> {
                 Evidence::SingleEndSequencingRead(read) => {
                     self.prob_sample_alt_read(read.seq().len() as u64, alignment_properties)
                 }
+                Evidence::OpticalMappingRead { .. } => todo!(),
             }
         }
     }

--- a/src/variants/types/deletion.rs
+++ b/src/variants/types/deletion.rs
@@ -193,6 +193,7 @@ impl<R: Realigner> Variant for Deletion<R> {
                     None
                 }
             }
+            Evidence::OpticalMappingRead { .. } => todo!(),
         }
     }
 
@@ -259,6 +260,7 @@ impl<R: Realigner> Variant for Deletion<R> {
 
                 Ok(Some(support))
             }
+            Evidence::OpticalMappingRead { .. } => todo!(),
         }
     }
 
@@ -290,6 +292,7 @@ impl<R: Realigner> Variant for Deletion<R> {
             Evidence::SingleEndSequencingRead(read) => {
                 self.prob_sample_alt_read(read.seq().len() as u64, alignment_properties)
             }
+            Evidence::OpticalMappingRead { .. } => todo!(),
         }
     }
 }

--- a/src/variants/types/insertion.rs
+++ b/src/variants/types/insertion.rs
@@ -147,6 +147,7 @@ impl<R: Realigner> Variant for Insertion<R> {
                 !self.locus().overlap(left, true).is_none()
                     || !self.locus().overlap(right, true).is_none()
             }
+            Evidence::OpticalMappingRead { .. } => todo!(),
         } {
             Some(vec![0])
         } else {
@@ -198,6 +199,7 @@ impl<R: Realigner> Variant for Insertion<R> {
 
                 Ok(Some(support))
             }
+            Evidence::OpticalMappingRead { .. } => todo!(),
         }
     }
 
@@ -221,6 +223,7 @@ impl<R: Realigner> Variant for Insertion<R> {
             Evidence::SingleEndSequencingRead(read) => {
                 self.prob_sample_alt_read(read.seq().len() as u64, alignment_properties)
             }
+            Evidence::OpticalMappingRead { .. } => todo!(),
         }
     }
 }

--- a/src/variants/types/mnv.rs
+++ b/src/variants/types/mnv.rs
@@ -257,6 +257,7 @@ impl<R: Realigner> Variant for Mnv<R> {
                     None
                 }
             }
+            Evidence::OpticalMappingRead { .. } => todo!(),
         }
     }
 
@@ -290,6 +291,7 @@ impl<R: Realigner> Variant for Mnv<R> {
                     (None, None) => Ok(None),
                 }
             }
+            Evidence::OpticalMappingRead { .. } => todo!(),
         }
     }
 

--- a/src/variants/types/mod.rs
+++ b/src/variants/types/mod.rs
@@ -243,6 +243,7 @@ where
                 }
                 p.ln_one_minus_exp()
             }
+            Evidence::OpticalMappingRead { .. } => todo!(),
         }
     }
 
@@ -252,6 +253,7 @@ where
             Evidence::PairedEndSequencingRead { left, right } => {
                 cmp::min(left.mapq(), right.mapq())
             }
+            Evidence::OpticalMappingRead { .. } => todo!(),
         }
     }
 
@@ -398,7 +400,7 @@ where
         for candidate in candidate_records.values() {
             let evidence = Evidence::OpticalMappingRead(
                 Rc::clone(&candidate),
-                Rc::clone(buffer.qry_record(candidate.id()))
+                Rc::clone(buffer.qry_record(candidate.id())),
             );
             if let Some(idx) = self.is_valid_evidence(&evidence, alignment_properties) {
                 evidences.push(evidence);

--- a/src/variants/types/mod.rs
+++ b/src/variants/types/mod.rs
@@ -382,7 +382,6 @@ where
         // Take self.loci() to get the loci of the variant, fetch overlapping records,
         // and wrap them as Evidence::OpticalMappingRead.
         let mut candidate_records = BTreeMap::new();
-
         for interval in self.loci().iter() {
             buffer.fetch(interval)?;
 
@@ -396,7 +395,6 @@ where
         }
 
         let mut evidences = Vec::new();
-
         for candidate in candidate_records.values() {
             let evidence = Evidence::OpticalMappingRead {
                 read: Rc::clone(&candidate),
@@ -407,12 +405,16 @@ where
             }
         }
 
-        Ok(evidences
-            .iter()
-            .map(|evidence| {
-                self.evidence_to_observation(evidence, alignment_properties, &None, &[], &mut None)
-            })
-            .collect())
+        let mut observations = Vec::new();
+        for evidence in &evidences {
+            if let Some(obs) =
+                self.evidence_to_observation(evidence, alignment_properties, &None, &[], &mut None)?
+            {
+                observations.push(obs);
+            }
+        }
+
+        Ok(observations)
     }
 }
 

--- a/src/variants/types/mod.rs
+++ b/src/variants/types/mod.rs
@@ -383,9 +383,7 @@ where
         // and wrap them as Evidence::OpticalMappingRead.
         let mut candidate_records = BTreeMap::new();
         for interval in self.loci().iter() {
-            buffer.fetch(interval)?;
-
-            for record in buffer.iter() {
+            for record in buffer.fetch(interval)? {
                 if !candidate_records.contains_key(record.id()) {
                     // this is the first (primary or supplementary) alignment in the pair
                     candidate_records.insert(record.id().to_owned(), record);

--- a/src/variants/types/mod.rs
+++ b/src/variants/types/mod.rs
@@ -395,10 +395,10 @@ where
         let mut evidences = Vec::new();
         for candidate in candidate_records.values() {
             let evidence = Evidence::OpticalMappingRead {
-                read: Rc::clone(&candidate),
-                alignment: Rc::clone(buffer.qry_record(candidate.id())),
+                read: Rc::clone(buffer.qry_record(candidate.qry_id())?),
+                alignment: Rc::clone(&candidate),
             };
-            if let Some(idx) = self.is_valid_evidence(&evidence, alignment_properties) {
+            if let Some(_) = self.is_valid_evidence(&evidence, alignment_properties) {
                 evidences.push(evidence);
             }
         }

--- a/src/variants/types/mod.rs
+++ b/src/variants/types/mod.rs
@@ -398,10 +398,10 @@ where
         let mut evidences = Vec::new();
 
         for candidate in candidate_records.values() {
-            let evidence = Evidence::OpticalMappingRead(
-                Rc::clone(&candidate),
-                Rc::clone(buffer.qry_record(candidate.id())),
-            );
+            let evidence = Evidence::OpticalMappingRead {
+                read: Rc::clone(&candidate),
+                alignment: Rc::clone(buffer.qry_record(candidate.id())),
+            };
             if let Some(idx) = self.is_valid_evidence(&evidence, alignment_properties) {
                 evidences.push(evidence);
             }

--- a/src/variants/types/mod.rs
+++ b/src/variants/types/mod.rs
@@ -384,7 +384,7 @@ where
         let mut candidate_records = BTreeMap::new();
 
         for interval in self.loci().iter() {
-            buffer.fetch(interval, true)?;
+            buffer.fetch(interval)?;
 
             for record in buffer.iter() {
                 if !candidate_records.contains_key(record.id()) {

--- a/src/variants/types/none.rs
+++ b/src/variants/types/none.rs
@@ -113,6 +113,7 @@ impl Variant for None {
                     None
                 }
             }
+            Evidence::OpticalMappingRead { .. } => todo!(),
         }
     }
 
@@ -142,6 +143,7 @@ impl Variant for None {
                     (None, None) => Ok(None),
                 }
             }
+            Evidence::OpticalMappingRead { .. } => todo!(),
         }
     }
 

--- a/src/variants/types/replacement.rs
+++ b/src/variants/types/replacement.rs
@@ -162,6 +162,7 @@ impl<R: Realigner> Variant for Replacement<R> {
                 !self.locus().overlap(left, true).is_none()
                     || !self.locus().overlap(right, true).is_none()
             }
+            Evidence::OpticalMappingRead { .. } => todo!(),
         } {
             Some(vec![0])
         } else {
@@ -213,6 +214,7 @@ impl<R: Realigner> Variant for Replacement<R> {
 
                 Ok(Some(support))
             }
+            Evidence::OpticalMappingRead { .. } => todo!(),
         }
     }
 
@@ -236,6 +238,7 @@ impl<R: Realigner> Variant for Replacement<R> {
             Evidence::SingleEndSequencingRead(read) => {
                 self.prob_sample_alt_read(read.seq().len() as u64, alignment_properties)
             }
+            Evidence::OpticalMappingRead { .. } => todo!(),
         }
     }
 }

--- a/src/variants/types/snv.rs
+++ b/src/variants/types/snv.rs
@@ -200,6 +200,7 @@ impl<R: Realigner> Variant for Snv<R> {
                     None
                 }
             }
+            Evidence::OpticalMappingRead { .. } => todo!(),
         }
     }
 
@@ -233,6 +234,7 @@ impl<R: Realigner> Variant for Snv<R> {
                     (None, None) => Ok(None),
                 }
             }
+            Evidence::OpticalMappingRead { .. } => todo!(),
         }
     }
 


### PR DESCRIPTION
### Description

Added support for optical mapping data.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
