### PR TITLE
feat: optical mapping support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,9 +215,8 @@ dependencies = [
 
 [[package]]
 name = "bio"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ffe04b598449a4486a45bc15884537a01cb2015d978ce66e51a47b2740ddbe"
+version = "2.0.3"
+source = "git+https://github.com/laurakuehle/rust-bio.git?branch=master#19fb4418096a5564e5565022b7975d2ea0536219"
 dependencies = [
  "anyhow",
  "approx",
@@ -227,10 +226,12 @@ dependencies = [
  "bytecount",
  "csv",
  "custom_derive",
+ "derive-new 0.6.0",
  "editdistancek",
  "enum-map",
  "fxhash",
- "itertools 0.13.0",
+ "getset",
+ "itertools 0.8.2",
  "itertools-num",
  "lazy_static",
  "multimap",
@@ -246,7 +247,7 @@ dependencies = [
  "serde_derive",
  "statrs",
  "strum",
- "strum_macros 0.26.4",
+ "strum_macros",
  "thiserror",
  "triple_accel",
  "vec_map",
@@ -258,28 +259,28 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d45749b87f21808051025e9bf714d14ff4627f9d8ca967eade6946ea769aa4a"
 dependencies = [
- "derive-new",
+ "derive-new 0.5.9",
  "lazy_static",
  "regex",
  "serde",
- "strum_macros 0.25.3",
+ "strum_macros",
  "thiserror",
 ]
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.6.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -637,6 +638,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-new"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d150dea618e920167e5973d70ae6ece4385b7164e0d799fe7c122dd0a5d912ad"
+dependencies = [
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 2.0.68",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -975,12 +987,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1101,15 +1107,6 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1877,7 +1874,7 @@ dependencies = [
  "bio-types",
  "byteorder",
  "custom_derive",
- "derive-new",
+ "derive-new 0.5.9",
  "hts-sys",
  "ieee754",
  "lazy_static",
@@ -2122,19 +2119,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
- "rustversion",
- "syn 2.0.68",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck 0.5.0",
  "proc-macro2 1.0.86",
  "quote 1.0.36",
  "rustversion",
@@ -2430,7 +2414,7 @@ dependencies = [
  "csv",
  "data-encoding",
  "derefable",
- "derive-new",
+ "derive-new 0.5.9",
  "derive_builder",
  "env_logger",
  "eval",
@@ -2467,7 +2451,7 @@ dependencies = [
  "statrs",
  "structopt",
  "strum",
- "strum_macros 0.25.3",
+ "strum_macros",
  "tempfile",
  "thiserror",
  "time",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ dependencies = [
 [[package]]
 name = "bio"
 version = "2.0.3"
-source = "git+https://github.com/laurakuehle/rust-bio.git?branch=master#19fb4418096a5564e5565022b7975d2ea0536219"
+source = "git+https://github.com/laurakuehle/rust-bio.git?branch=master#d366a0d8d6e417bcb3b854984dc00007c1729e9c"
 dependencies = [
  "anyhow",
  "approx",
@@ -239,7 +239,7 @@ dependencies = [
  "newtype_derive",
  "num-integer",
  "num-traits",
- "ordered-float 4.2.1",
+ "ordered-float 4.3.0",
  "petgraph",
  "rand 0.8.5",
  "regex",
@@ -1512,9 +1512,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "4.2.1"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ff2cf528c6c03d9ed653d6c4ce1dc0582dc4af309790ad92f07c1cd551b0be"
+checksum = "44d501f1a72f71d3c063a6bbc8f7271fa73aa09fe5d6283b6571e2ed176a2537"
 dependencies = [
  "num-traits",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ approx = "0.5.0"
 askama = "0.11.1"
 auto_ops = "0.3.0"
 bincode = "1.3"
-bio = "2.0.0"
+bio = {git="https://github.com/laurakuehle/rust-bio.git", branch="master"} #"2.0.0"
 bio-types = { version = ">=0.12", features = ["serde"] }
 boolean_expression = "0.4"
 bv = "0.11"

--- a/src/variants/sample.rs
+++ b/src/variants/sample.rs
@@ -9,6 +9,8 @@ use std::rc::Rc;
 use std::str;
 
 use anyhow::Result;
+use bio::io::om::bnx;
+use bio::io::om::xmap;
 use bio_types::{genome, genome::AbstractInterval};
 use derive_builder::Builder;
 use rand::distributions;
@@ -81,12 +83,27 @@ impl SequencingRecordBuffer {
     }
 }
 
-
+#[derive(new, Getters, Debug)]
 pub(crate) struct OpticalMappingRecordBuffer {
-
+    xmap: xmap::Container,
+    bnx: bnx::Container,
 }
 
 impl OpticalMappingRecordBuffer {
+    pub(crate) fn fetch(
+        &self,
+        interval: &genome::Interval,
+    ) -> Result<impl Iterator<Item = &Rc<xmap::Record>>> {
+        self.xmap.fetch(
+            interval.contig().parse::<u32>()?,
+            interval.range().start,
+            interval.range().end,
+        )
+    }
+
+    pub(crate) fn qry_record(&self, bnx_id: &u32) -> Result<&Rc<bnx::Record>> {
+        self.bnx.record(bnx_id.clone())
+    }
 }
 
 #[derive(Default, Derefable)]

--- a/src/variants/sample.rs
+++ b/src/variants/sample.rs
@@ -30,7 +30,7 @@ use super::types::Loci;
 use crate::variants::evidence::observations::pileup::Pileup;
 
 #[derive(new, Getters, Debug)]
-pub(crate) struct RecordBuffer {
+pub(crate) struct SequencingRecordBuffer {
     inner: bam::RecordBuffer,
     #[getset(get = "pub")]
     single_read_window: u64,
@@ -38,7 +38,7 @@ pub(crate) struct RecordBuffer {
     read_pair_window: u64,
 }
 
-impl RecordBuffer {
+impl SequencingRecordBuffer {
     pub(crate) fn window(&self, read_pair_mode: bool, left: bool) -> u64 {
         if read_pair_mode {
             self.read_pair_window
@@ -79,6 +79,14 @@ impl RecordBuffer {
             .filter(|record| is_valid_record(record.as_ref()))
             .map(Rc::clone)
     }
+}
+
+
+pub(crate) struct OpticalMappingRecordBuffer {
+
+}
+
+impl OpticalMappingRecordBuffer {
 }
 
 #[derive(Default, Derefable)]
@@ -158,7 +166,7 @@ pub(crate) fn estimate_alignment_properties<P: AsRef<Path>>(
 #[builder(pattern = "owned")]
 pub(crate) struct Sample {
     #[builder(private)]
-    record_buffer: RecordBuffer,
+    record_buffer: SequencingRecordBuffer,
     #[builder(private)]
     alignment_properties: alignment_properties::AlignmentProperties,
     #[builder(default = "200")]
@@ -196,7 +204,7 @@ impl SampleBuilder {
         let mut record_buffer = bam::RecordBuffer::new(bam, true);
         record_buffer.set_min_refetch_distance(min_refetch_distance);
         self.alignment_properties(alignment_properties)
-            .record_buffer(RecordBuffer::new(
+            .record_buffer(SequencingRecordBuffer::new(
                 record_buffer,
                 single_read_window,
                 read_pair_window,
@@ -237,7 +245,7 @@ impl Sample {
             None
         };
 
-        let observations = variant.extract_observations(
+        let observations = variant.extract_sequencing_read_observations(
             &mut self.record_buffer,
             &mut self.alignment_properties,
             self.max_depth,

--- a/src/variants/types/breakends.rs
+++ b/src/variants/types/breakends.rs
@@ -296,6 +296,7 @@ impl<R: Realigner> BreakendGroup<R> {
                 None
             }
             Evidence::SingleEndSequencingRead(_) => None,
+            Evidence::OpticalMappingRead { .. } => todo!(),
         }
     }
 }
@@ -376,6 +377,7 @@ impl<R: Realigner> Variant for BreakendGroup<R> {
                         })
                         .collect()
                 }
+                Evidence::OpticalMappingRead { .. } => todo!(),
             };
 
             if overlapping.is_empty() {
@@ -451,6 +453,7 @@ impl<R: Realigner> Variant for BreakendGroup<R> {
                             "bug: single end reads cannot be used as evidence for \
                              imprecise breakend groups"
                         ),
+                        Evidence::OpticalMappingRead { .. } => todo!(),
                     }
                 }
 
@@ -516,6 +519,7 @@ impl<R: Realigner> Variant for BreakendGroup<R> {
 
                     Ok(Some(support))
                 }
+                Evidence::OpticalMappingRead { .. } => todo!(),
             }
         }
     }
@@ -546,6 +550,7 @@ impl<R: Realigner> Variant for BreakendGroup<R> {
                 Evidence::SingleEndSequencingRead(read) => {
                     self.prob_sample_alt_read(read.seq().len() as u64, alignment_properties)
                 }
+                Evidence::OpticalMappingRead { .. } => todo!(),
             }
         }
     }

--- a/src/variants/types/breakends.rs
+++ b/src/variants/types/breakends.rs
@@ -271,7 +271,7 @@ impl<R: Realigner> BreakendGroup<R> {
         };
 
         match evidence {
-            Evidence::PairedEnd { left, right } => {
+            Evidence::PairedEndSequencingRead { left, right } => {
                 assert_eq!(self.breakends.len(), 2);
                 for bnds in self.breakends.values().permutations(2) {
                     let (bnd, other_bnd) = (bnds[0], bnds[1]);
@@ -295,7 +295,7 @@ impl<R: Realigner> BreakendGroup<R> {
                 }
                 None
             }
-            Evidence::SingleEnd(_) => None,
+            Evidence::SingleEndSequencingRead(_) => None,
         }
     }
 }
@@ -343,7 +343,7 @@ impl<R: Realigner> Variant for BreakendGroup<R> {
             };
 
             let overlapping: Vec<_> = match evidence {
-                Evidence::SingleEnd(read) => {
+                Evidence::SingleEndSequencingRead(read) => {
                     if !is_valid_ref_bases(read) {
                         return None;
                     }
@@ -359,7 +359,7 @@ impl<R: Realigner> Variant for BreakendGroup<R> {
                         })
                         .collect()
                 }
-                Evidence::PairedEnd { left, right } => {
+                Evidence::PairedEndSequencingRead { left, right } => {
                     if !is_valid_ref_bases(left) && !is_valid_ref_bases(right) {
                         return None;
                     }
@@ -402,7 +402,7 @@ impl<R: Realigner> Variant for BreakendGroup<R> {
             if let Some(classification) = self.classify_imprecise_evidence(evidence) {
                 if self.is_deletion() {
                     match evidence {
-                        Evidence::PairedEnd { left, right } => {
+                        Evidence::PairedEndSequencingRead { left, right } => {
                             if let Some((left_bnd, right_bnd)) = self.breakend_pair() {
                                 // METHOD: we consider all possible lengths of the deletion,
                                 // use a uniform prior and sum up the joint probabilities for the alt allele.
@@ -447,7 +447,7 @@ impl<R: Realigner> Variant for BreakendGroup<R> {
                                 )
                             }
                         }
-                        Evidence::SingleEnd(_) => unreachable!(
+                        Evidence::SingleEndSequencingRead(_) => unreachable!(
                             "bug: single end reads cannot be used as evidence for \
                              imprecise breakend groups"
                         ),
@@ -485,7 +485,7 @@ impl<R: Realigner> Variant for BreakendGroup<R> {
             }
         } else {
             match evidence {
-                Evidence::SingleEnd(record) => {
+                Evidence::SingleEndSequencingRead(record) => {
                     Ok(Some(self.realigner.borrow_mut().allele_support(
                         record,
                         self.loci.iter(),
@@ -494,7 +494,7 @@ impl<R: Realigner> Variant for BreakendGroup<R> {
                         alignment_properties,
                     )?))
                 }
-                Evidence::PairedEnd { left, right } => {
+                Evidence::PairedEndSequencingRead { left, right } => {
                     let left_support = self.realigner.borrow_mut().allele_support(
                         left,
                         self.loci.iter(),
@@ -532,7 +532,7 @@ impl<R: Realigner> Variant for BreakendGroup<R> {
             LogProb::ln_one()
         } else {
             match evidence {
-                Evidence::PairedEnd { left, right } => {
+                Evidence::PairedEndSequencingRead { left, right } => {
                     // METHOD: we do not require the fragment to enclose the breakend group.
                     // Hence, we treat both reads independently.
                     (self
@@ -543,7 +543,7 @@ impl<R: Realigner> Variant for BreakendGroup<R> {
                             .ln_one_minus_exp())
                     .ln_one_minus_exp()
                 }
-                Evidence::SingleEnd(read) => {
+                Evidence::SingleEndSequencingRead(read) => {
                     self.prob_sample_alt_read(read.seq().len() as u64, alignment_properties)
                 }
             }

--- a/src/variants/types/deletion.rs
+++ b/src/variants/types/deletion.rs
@@ -193,6 +193,7 @@ impl<R: Realigner> Variant for Deletion<R> {
                     None
                 }
             }
+            Evidence::OpticalMappingRead { .. } => todo!(),
         }
     }
 
@@ -259,6 +260,7 @@ impl<R: Realigner> Variant for Deletion<R> {
 
                 Ok(Some(support))
             }
+            Evidence::OpticalMappingRead { .. } => todo!(),
         }
     }
 
@@ -290,6 +292,7 @@ impl<R: Realigner> Variant for Deletion<R> {
             Evidence::SingleEndSequencingRead(read) => {
                 self.prob_sample_alt_read(read.seq().len() as u64, alignment_properties)
             }
+            Evidence::OpticalMappingRead { .. } => todo!(),
         }
     }
 }

--- a/src/variants/types/insertion.rs
+++ b/src/variants/types/insertion.rs
@@ -142,8 +142,8 @@ impl<R: Realigner> Variant for Insertion<R> {
         _: &AlignmentProperties,
     ) -> Option<Vec<usize>> {
         if match evidence {
-            Evidence::SingleEnd(read) => !self.locus().overlap(read, true).is_none(),
-            Evidence::PairedEnd { left, right } => {
+            Evidence::SingleEndSequencingRead(read) => !self.locus().overlap(read, true).is_none(),
+            Evidence::PairedEndSequencingRead { left, right } => {
                 !self.locus().overlap(left, true).is_none()
                     || !self.locus().overlap(right, true).is_none()
             }
@@ -167,14 +167,16 @@ impl<R: Realigner> Variant for Insertion<R> {
         alt_variants: &[Box<dyn Realignable>],
     ) -> Result<Option<AlleleSupport>> {
         match evidence {
-            Evidence::SingleEnd(record) => Ok(Some(self.realigner.borrow_mut().allele_support(
-                record,
-                self.locus.iter(),
-                self,
-                alt_variants,
-                alignment_properties,
-            )?)),
-            Evidence::PairedEnd { left, right } => {
+            Evidence::SingleEndSequencingRead(record) => {
+                Ok(Some(self.realigner.borrow_mut().allele_support(
+                    record,
+                    self.locus.iter(),
+                    self,
+                    alt_variants,
+                    alignment_properties,
+                )?))
+            }
+            Evidence::PairedEndSequencingRead { left, right } => {
                 let left_support = self.realigner.borrow_mut().allele_support(
                     left,
                     self.locus.iter(),
@@ -205,7 +207,7 @@ impl<R: Realigner> Variant for Insertion<R> {
         alignment_properties: &AlignmentProperties,
     ) -> LogProb {
         match evidence {
-            Evidence::PairedEnd { left, right } => {
+            Evidence::PairedEndSequencingRead { left, right } => {
                 // METHOD: we do not require the fragment to enclose the variant.
                 // Hence, we treat both reads independently.
                 (self
@@ -216,7 +218,7 @@ impl<R: Realigner> Variant for Insertion<R> {
                         .ln_one_minus_exp())
                 .ln_one_minus_exp()
             }
-            Evidence::SingleEnd(read) => {
+            Evidence::SingleEndSequencingRead(read) => {
                 self.prob_sample_alt_read(read.seq().len() as u64, alignment_properties)
             }
         }

--- a/src/variants/types/insertion.rs
+++ b/src/variants/types/insertion.rs
@@ -147,6 +147,7 @@ impl<R: Realigner> Variant for Insertion<R> {
                 !self.locus().overlap(left, true).is_none()
                     || !self.locus().overlap(right, true).is_none()
             }
+            Evidence::OpticalMappingRead { .. } => todo!(),
         } {
             Some(vec![0])
         } else {
@@ -198,6 +199,7 @@ impl<R: Realigner> Variant for Insertion<R> {
 
                 Ok(Some(support))
             }
+            Evidence::OpticalMappingRead { .. } => todo!(),
         }
     }
 
@@ -221,6 +223,7 @@ impl<R: Realigner> Variant for Insertion<R> {
             Evidence::SingleEndSequencingRead(read) => {
                 self.prob_sample_alt_read(read.seq().len() as u64, alignment_properties)
             }
+            Evidence::OpticalMappingRead { .. } => todo!(),
         }
     }
 }

--- a/src/variants/types/mnv.rs
+++ b/src/variants/types/mnv.rs
@@ -257,6 +257,7 @@ impl<R: Realigner> Variant for Mnv<R> {
                     None
                 }
             }
+            Evidence::OpticalMappingRead { .. } => todo!(),
         }
     }
 
@@ -290,6 +291,7 @@ impl<R: Realigner> Variant for Mnv<R> {
                     (None, None) => Ok(None),
                 }
             }
+            Evidence::OpticalMappingRead { .. } => todo!(),
         }
     }
 

--- a/src/variants/types/mnv.rs
+++ b/src/variants/types/mnv.rs
@@ -241,14 +241,14 @@ impl<R: Realigner> Variant for Mnv<R> {
         _: &AlignmentProperties,
     ) -> Option<Vec<usize>> {
         match evidence {
-            Evidence::SingleEnd(read) => {
+            Evidence::SingleEndSequencingRead(read) => {
                 if let Overlap::Enclosing = self.locus().overlap(read, false) {
                     Some(vec![0])
                 } else {
                     None
                 }
             }
-            Evidence::PairedEnd { left, right } => {
+            Evidence::PairedEndSequencingRead { left, right } => {
                 if let Overlap::Enclosing = self.locus().overlap(left, false) {
                     Some(vec![0])
                 } else if let Overlap::Enclosing = self.locus().overlap(right, false) {
@@ -271,10 +271,10 @@ impl<R: Realigner> Variant for Mnv<R> {
         alt_variants: &[Box<dyn Realignable>],
     ) -> Result<Option<AlleleSupport>> {
         match evidence {
-            Evidence::SingleEnd(read) => {
+            Evidence::SingleEndSequencingRead(read) => {
                 Ok(self.allele_support_per_read(read, alignment_properties, alt_variants)?)
             }
-            Evidence::PairedEnd { left, right } => {
+            Evidence::PairedEndSequencingRead { left, right } => {
                 let left_support =
                     self.allele_support_per_read(left, alignment_properties, alt_variants)?;
                 let right_support =

--- a/src/variants/types/mod.rs
+++ b/src/variants/types/mod.rs
@@ -255,9 +255,9 @@ where
         }
     }
 
-    fn extract_observations(
+    fn extract_sequencing_read_observations(
         &self,
-        buffer: &mut sample::RecordBuffer,
+        buffer: &mut sample::SequencingRecordBuffer,
         alignment_properties: &mut AlignmentProperties,
         max_depth: usize,
         alt_variants: &[Box<dyn Realignable>],
@@ -369,6 +369,27 @@ where
         }
 
         Ok(observations)
+    }
+
+    fn extract_optical_mapping_observations(
+        &self,
+        buffer: &mut sample::OpticalMappingRecordBuffer,
+        alignment_properties: &mut AlignmentProperties,
+    ) -> Result<Vec<ReadObservation>> {
+        // TODO implement analogously (but will be much simpler) to extract_sequencing_read_observations
+        // Take self.loci() to get the loci of the variant, fetch overlapping records,
+        // and wrap them as Evidence::OpticalMappingRead.
+        let evidences = ...;
+
+        Ok(evidences.iter().map(|evidence| {
+            self.evidence_to_observation(
+                evidence,
+                alignment_properties,
+                &None,
+                &[],
+                &mut None,
+            )
+        }).collect())
     }
 }
 

--- a/src/variants/types/none.rs
+++ b/src/variants/types/none.rs
@@ -113,6 +113,7 @@ impl Variant for None {
                     None
                 }
             }
+            Evidence::OpticalMappingRead { .. } => todo!(),
         }
     }
 
@@ -142,6 +143,7 @@ impl Variant for None {
                     (None, None) => Ok(None),
                 }
             }
+            Evidence::OpticalMappingRead { .. } => todo!(),
         }
     }
 

--- a/src/variants/types/none.rs
+++ b/src/variants/types/none.rs
@@ -97,14 +97,14 @@ impl Variant for None {
         _: &AlignmentProperties,
     ) -> Option<Vec<usize>> {
         match evidence {
-            Evidence::SingleEnd(read) => {
+            Evidence::SingleEndSequencingRead(read) => {
                 if let Overlap::Enclosing = self.locus().overlap(read, false) {
                     Some(vec![0])
                 } else {
                     None
                 }
             }
-            Evidence::PairedEnd { left, right } => {
+            Evidence::PairedEndSequencingRead { left, right } => {
                 if let Overlap::Enclosing = self.locus().overlap(left, false) {
                     Some(vec![0])
                 } else if let Overlap::Enclosing = self.locus().overlap(right, false) {
@@ -127,8 +127,8 @@ impl Variant for None {
         _: &[Box<dyn Realignable>],
     ) -> Result<Option<AlleleSupport>> {
         match evidence {
-            Evidence::SingleEnd(read) => Ok(self.allele_support_per_read(read)?),
-            Evidence::PairedEnd { left, right } => {
+            Evidence::SingleEndSequencingRead(read) => Ok(self.allele_support_per_read(read)?),
+            Evidence::PairedEndSequencingRead { left, right } => {
                 let left_support = self.allele_support_per_read(left)?;
                 let right_support = self.allele_support_per_read(right)?;
 

--- a/src/variants/types/replacement.rs
+++ b/src/variants/types/replacement.rs
@@ -157,8 +157,8 @@ impl<R: Realigner> Variant for Replacement<R> {
         _: &AlignmentProperties,
     ) -> Option<Vec<usize>> {
         if match evidence {
-            Evidence::SingleEnd(read) => !self.locus().overlap(read, true).is_none(),
-            Evidence::PairedEnd { left, right } => {
+            Evidence::SingleEndSequencingRead(read) => !self.locus().overlap(read, true).is_none(),
+            Evidence::PairedEndSequencingRead { left, right } => {
                 !self.locus().overlap(left, true).is_none()
                     || !self.locus().overlap(right, true).is_none()
             }
@@ -182,14 +182,16 @@ impl<R: Realigner> Variant for Replacement<R> {
         alt_variants: &[Box<dyn Realignable>],
     ) -> Result<Option<AlleleSupport>> {
         match evidence {
-            Evidence::SingleEnd(record) => Ok(Some(self.realigner.borrow_mut().allele_support(
-                record,
-                self.loci.iter(),
-                self,
-                alt_variants,
-                alignment_properties,
-            )?)),
-            Evidence::PairedEnd { left, right } => {
+            Evidence::SingleEndSequencingRead(record) => {
+                Ok(Some(self.realigner.borrow_mut().allele_support(
+                    record,
+                    self.loci.iter(),
+                    self,
+                    alt_variants,
+                    alignment_properties,
+                )?))
+            }
+            Evidence::PairedEndSequencingRead { left, right } => {
                 let left_support = self.realigner.borrow_mut().allele_support(
                     left,
                     self.loci.iter(),
@@ -220,7 +222,7 @@ impl<R: Realigner> Variant for Replacement<R> {
         alignment_properties: &AlignmentProperties,
     ) -> LogProb {
         match evidence {
-            Evidence::PairedEnd { left, right } => {
+            Evidence::PairedEndSequencingRead { left, right } => {
                 // METHOD: we do not require the fragment to enclose the variant.
                 // Hence, we treat both reads independently.
                 (self
@@ -231,7 +233,7 @@ impl<R: Realigner> Variant for Replacement<R> {
                         .ln_one_minus_exp())
                 .ln_one_minus_exp()
             }
-            Evidence::SingleEnd(read) => {
+            Evidence::SingleEndSequencingRead(read) => {
                 self.prob_sample_alt_read(read.seq().len() as u64, alignment_properties)
             }
         }

--- a/src/variants/types/replacement.rs
+++ b/src/variants/types/replacement.rs
@@ -162,6 +162,7 @@ impl<R: Realigner> Variant for Replacement<R> {
                 !self.locus().overlap(left, true).is_none()
                     || !self.locus().overlap(right, true).is_none()
             }
+            Evidence::OpticalMappingRead { .. } => todo!(),
         } {
             Some(vec![0])
         } else {
@@ -213,6 +214,7 @@ impl<R: Realigner> Variant for Replacement<R> {
 
                 Ok(Some(support))
             }
+            Evidence::OpticalMappingRead { .. } => todo!(),
         }
     }
 
@@ -236,6 +238,7 @@ impl<R: Realigner> Variant for Replacement<R> {
             Evidence::SingleEndSequencingRead(read) => {
                 self.prob_sample_alt_read(read.seq().len() as u64, alignment_properties)
             }
+            Evidence::OpticalMappingRead { .. } => todo!(),
         }
     }
 }

--- a/src/variants/types/snv.rs
+++ b/src/variants/types/snv.rs
@@ -184,14 +184,14 @@ impl<R: Realigner> Variant for Snv<R> {
         _: &AlignmentProperties,
     ) -> Option<Vec<usize>> {
         match evidence {
-            Evidence::SingleEnd(read) => {
+            Evidence::SingleEndSequencingRead(read) => {
                 if let Overlap::Enclosing = self.locus().overlap(read, false) {
                     Some(vec![0])
                 } else {
                     None
                 }
             }
-            Evidence::PairedEnd { left, right } => {
+            Evidence::PairedEndSequencingRead { left, right } => {
                 if let Overlap::Enclosing = self.locus().overlap(left, false) {
                     Some(vec![0])
                 } else if let Overlap::Enclosing = self.locus().overlap(right, false) {
@@ -214,10 +214,10 @@ impl<R: Realigner> Variant for Snv<R> {
         alt_variants: &[Box<dyn Realignable>],
     ) -> Result<Option<AlleleSupport>> {
         match evidence {
-            Evidence::SingleEnd(read) => {
+            Evidence::SingleEndSequencingRead(read) => {
                 Ok(self.allele_support_per_read(read, alignment_properties, alt_variants)?)
             }
-            Evidence::PairedEnd { left, right } => {
+            Evidence::PairedEndSequencingRead { left, right } => {
                 let left_support =
                     self.allele_support_per_read(left, alignment_properties, alt_variants)?;
                 let right_support =

--- a/src/variants/types/snv.rs
+++ b/src/variants/types/snv.rs
@@ -200,6 +200,7 @@ impl<R: Realigner> Variant for Snv<R> {
                     None
                 }
             }
+            Evidence::OpticalMappingRead { .. } => todo!(),
         }
     }
 
@@ -233,6 +234,7 @@ impl<R: Realigner> Variant for Snv<R> {
                     (None, None) => Ok(None),
                 }
             }
+            Evidence::OpticalMappingRead { .. } => todo!(),
         }
     }
 


### PR DESCRIPTION
### Description

Added support for optical mapping data.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
