### PR TITLE
build: Update strum dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,8 +61,8 @@ serde_yaml = ">=0.8.4,<0.9"
 shrinkwraprs = "0.3.0"
 statrs = "0.16"
 structopt = "0.3"
-strum = ">= 0.16, < 0.26" # Needs to be in sync with rust-bios strum dependency
-strum_macros = ">= 0.16, < 0.26"
+strum = ">= 0.16, < 0.27" # Needs to be in sync with rust-bios strum dependency
+strum_macros = ">= 0.16, < 0.27"
 tempfile = "3"
 thiserror = "1.0"
 time = "0.3"


### PR DESCRIPTION
This PR updates the strum dependencies to stay in sync with rust bio - see https://github.com/rust-bio/rust-bio/pull/588. This is needed because projects depending on both rust-bio and varlociraptor won't compile otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated version constraints for `strum` and `strum_macros` dependencies to ensure compatibility with the `rust-bios` package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->