### PR TITLE
refactor: rename HEURISTICS field into the more generic HINTS

### DIFF
--- a/src/calling/variants/calling.rs
+++ b/src/calling/variants/calling.rs
@@ -40,7 +40,7 @@ use crate::variants::model::{Contamination, HaplotypeIdentifier};
 
 use super::preprocessing::haplotype_feature_index::HaplotypeFeatureIndex;
 use super::preprocessing::Observations;
-use super::Heuristic;
+use super::Hint;
 
 pub(crate) type AlleleFreqCombination = LikelihoodOperands;
 
@@ -127,9 +127,9 @@ where
         );
 
         header.push_record(
-            b"##INFO=<ID=HEURISTICS,Number=.,Type=String,\
-             Description=\"Applied heuristics. This field holds a list of heuristics\
-             applied for the calling. The following heuristics are possible: \
+            b"##INFO=<ID=HINTS,Number=.,Type=String,\
+             Description=\"Hints about applied heuristics and other events that occured \
+             during model evaluation. The following hints are possible: \
              adjusted-singleton-evidence: in case of a single read supporting the variant \
              across all samples, we assume that it is unclear whether that is a PCR \
              error or not. Hence, the likelihood of the variant and ref allele is set \
@@ -578,12 +578,12 @@ where
         if adjust_singleton_evidence(&mut pileups) {
             work_item
                 .call
-                .register_heuristic(Heuristic::AdjustedSingletonEvidence);
+                .register_heuristic(Hint::AdjustedSingletonEvidence);
         }
         if filtered_alignments {
             work_item
                 .call
-                .register_heuristic(Heuristic::FilteredNonStandardAlignments);
+                .register_heuristic(Hint::FilteredNonStandardAlignments);
         }
 
         work_item.pileups = Some(pileups);

--- a/src/calling/variants/mod.rs
+++ b/src/calling/variants/mod.rs
@@ -51,7 +51,7 @@ lazy_static! {
 
 #[derive(EnumString, Hash, Eq, PartialEq, Debug, Clone, Copy, IntoStaticStr, Display)]
 #[strum(serialize_all = "kebab_case")]
-pub(crate) enum Heuristic {
+pub(crate) enum Hint {
     AdjustedSingletonEvidence,
     FilteredNonStandardAlignments,
 }
@@ -68,7 +68,7 @@ pub(crate) struct Call {
     #[builder(default)]
     aux_info: AuxInfo,
     #[builder(default)]
-    heuristics: HashSet<Heuristic>,
+    hints: HashSet<Hint>,
     //aux_fields: HashSet<Vec<u8>>,
     #[builder(default)]
     variant: Option<Variant>,
@@ -81,8 +81,8 @@ impl CallBuilder {
 }
 
 impl Call {
-    pub(crate) fn register_heuristic(&mut self, heuristic: Heuristic) {
-        self.heuristics.insert(heuristic);
+    pub(crate) fn register_heuristic(&mut self, heuristic: Hint) {
+        self.hints.insert(heuristic);
     }
 
     pub(crate) fn write_preprocessed_record(&self, bcf_writer: &mut bcf::Writer) -> Result<()> {
@@ -400,13 +400,13 @@ impl Call {
         if let Some(ref mateid) = self.mateid {
             record.push_info_string(b"MATEID", &[mateid])?;
         }
-        if !self.heuristics.is_empty() {
-            let heuristics: Vec<&[u8]> = self
-                .heuristics
+        if !self.hints.is_empty() {
+            let hints: Vec<&[u8]> = self
+                .hints
                 .iter()
-                .map(|heuristic| <&Heuristic as Into<&'static str>>::into(heuristic).as_bytes())
+                .map(|hint| <&Hint as Into<&'static str>>::into(hint).as_bytes())
                 .collect();
-            record.push_info_string(b"HEURISTICS", &heuristics)?;
+            record.push_info_string(b"HINTS", &hints)?;
         }
 
         self.aux_info.write(&mut record, &OMIT_AUX_INFO)?;


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Renamed terminology from "Heuristic" to "Hint" across the application to improve clarity.
	- Updated methods and fields to reflect the new naming convention, enhancing consistency in the codebase.

- **Documentation**
	- Revised documentation strings to align with the updated terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->