### PR TITLE
chore: fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Varlociraptor implements a novel, unified fully uncertainty-aware approach to ge
 
 ### Calling modes
 
-* Generic, grammar based configuration of the statistical model, allowing to classify arbitrary scenarios, from poplation genetics, to pedigrees, complex tumor scenarios and arbitrary combinations thereof.
+* Generic, grammar based configuration of the statistical model, allowing to classify arbitrary scenarios, from population genetics, to pedigrees, complex tumor scenarios and arbitrary combinations thereof.
 * Tumor-normal-calling, classifying variants as somatic in tumor, somatic in normal, germline, or absent.
 
 **For details, see the homepage: https://varlociraptor.github.io**


### PR DESCRIPTION
Simple typo fix in `README.md`