### PR TITLE
fix: read position bias causing biased allele frequency estimates

### DIFF
--- a/src/variants/model/bias/homopolymer_error.rs
+++ b/src/variants/model/bias/homopolymer_error.rs
@@ -53,13 +53,14 @@ impl Bias for HomopolymerError {
         // because it seems to rather support an indel in one particular direction.
         pileups.iter().all(|pileup| {
             let has_homopolymer_indel = |ins: bool| {
-                pileup
-                    .read_observations()
-                    .iter()
-                    .any(|obs| {
-                        let indel = obs.homopolymer_indel_len.unwrap_or(0);
-                        if ins { indel > 0 } else { indel < 0 }
-                    })
+                pileup.read_observations().iter().any(|obs| {
+                    let indel = obs.homopolymer_indel_len.unwrap_or(0);
+                    if ins {
+                        indel > 0
+                    } else {
+                        indel < 0
+                    }
+                })
             };
 
             !pileup

--- a/src/variants/model/bias/read_position_bias.rs
+++ b/src/variants/model/bias/read_position_bias.rs
@@ -1,7 +1,5 @@
 use bio::stats::probs::LogProb;
-use bio::stats::Prob;
 use itertools::Itertools;
-use ordered_float::NotNan;
 
 use crate::variants::evidence::observations::pileup::Pileup;
 use crate::variants::evidence::observations::read_observation::{
@@ -11,23 +9,23 @@ use crate::variants::model::bias::Bias;
 
 #[derive(Copy, Clone, PartialOrd, PartialEq, Eq, Debug, Ord, EnumIter, Hash)]
 pub(crate) enum ReadPositionBias {
-    None { major_rate: Option<NotNan<f64>> },
+    None,
     Some,
 }
 
 impl Default for ReadPositionBias {
     fn default() -> Self {
-        ReadPositionBias::None { major_rate: None }
+        ReadPositionBias::None
     }
 }
 
 impl Bias for ReadPositionBias {
     fn prob_alt(&self, observation: &ProcessedReadObservation) -> LogProb {
         match (self, observation.read_position) {
-            (ReadPositionBias::None { major_rate: _ }, ReadPosition::Major) => {
+            (ReadPositionBias::None, ReadPosition::Major) => {
                 observation.prob_hit_base
             }
-            (ReadPositionBias::None { major_rate: _ }, ReadPosition::Some) => {
+            (ReadPositionBias::None, ReadPosition::Some) => {
                 observation.prob_hit_base.ln_one_minus_exp()
             }
             (ReadPositionBias::Some, ReadPosition::Major) => LogProb::ln_one(), // bias
@@ -36,78 +34,75 @@ impl Bias for ReadPositionBias {
     }
 
     fn prob_any(&self, observation: &ProcessedReadObservation) -> LogProb {
+        // METHOD: It is important that the probability of the read position bias is
+        // is the same for both alt and ref reads in case the bias is None.
+        // Otherwise, the model can be drawn to wrong AF estimates.
         match observation.read_position {
-            ReadPosition::Major => observation.prob_hit_base,
-            ReadPosition::Some => observation.prob_hit_base.ln_one_minus_exp(),
+            ReadPosition::Major => {
+                observation.prob_hit_base
+            }
+            ReadPosition::Some => {
+                observation.prob_hit_base.ln_one_minus_exp()
+            }
         }
     }
 
     fn is_artifact(&self) -> bool {
-        !matches!(self, ReadPositionBias::None { .. })
+        *self != ReadPositionBias::None
     }
 
     fn is_informative(&self, pileups: &[Pileup]) -> bool {
         // METHOD: if all reads overlap the variant at the major pos,
         // we cannot estimate a read position bias and None is the only informative one.
-        !self.is_artifact() || Self::estimate_major_rate(pileups).is_some()
-    }
-
-    fn learn_parameters(&mut self, pileups: &[Pileup]) {
-        if let ReadPositionBias::None { ref mut major_rate } = self {
-            *major_rate = Self::estimate_major_rate(pileups);
-        }
+        !self.is_artifact() || Self::has_valid_major_rate(pileups)
     }
 }
 
 impl ReadPositionBias {
-    fn estimate_major_rate(pileups: &[Pileup]) -> Option<NotNan<f64>> {
-        let strong_all = LogProb::ln_sum_exp(
-            &pileups
+    fn has_valid_major_rate(pileups: &[Pileup]) -> bool {
+        // TODO what happens when we combine amplicon and WGS here?
+        // The former might give a hint for a bias because of the way amplicons
+        // are designed, while the latter might not have a bias.
+        pileups.iter().any(|pileup| {
+            let expected_all = LogProb::ln_sum_exp(&pileup
+                .read_observations()
                 .iter()
-                .flat_map(|pileup| {
-                    pileup.read_observations().iter().filter_map(|obs| {
-                        if obs.is_strong_ref_support() {
-                            Some(obs.prob_mapping())
-                        } else {
-                            None
-                        }
-                    })
-                })
-                .collect_vec(),
-        )
-        .exp();
-        let strong_major = LogProb::ln_sum_exp(
-            &pileups
-                .iter()
-                .flat_map(|pileup| {
-                    pileup.read_observations().iter().filter_map(|obs| {
+                .filter_map(|obs| {
+                    if obs.is_strong_ref_support() {
+                        Some(obs.prob_mapping())
+                    } else {
+                        None
+                    }
+                }).collect_vec()).exp();
+
+            if expected_all > 10.0 {
+                let expected_major = LogProb::ln_sum_exp(&pileup
+                    .read_observations()
+                    .iter()
+                    .filter_map(|obs| {
                         if obs.is_strong_ref_support() && obs.read_position == ReadPosition::Major {
                             Some(obs.prob_mapping())
                         } else {
                             None
                         }
-                    })
-                })
-                .collect_vec(),
-        )
-        .exp();
-        let any_major = pileups.iter().any(|pileup| {
-            pileup
-                .read_observations()
-                .iter()
-                .any(|obs| obs.read_position == ReadPosition::Major)
-        });
-
-        if strong_all > 2.0 {
-            let major_fraction = strong_major / strong_all;
-            if any_major && major_fraction < 1.0 {
-                // METHOD: if there is any read with the major read position in either
-                // the ref or the alt supporting strong evidences and not all the reads
-                // supporting ref do that at the major position, we report a fraction
-                // and consider the read position bias.
-                return Some(NotNan::new(major_fraction).unwrap());
+                    }).collect_vec()).exp();
+                
+                let expected_major_rate = LogProb::ln_sum_exp(&pileup
+                    .read_observations()
+                    .iter()
+                    .filter_map(|obs| {
+                        if obs.is_strong_ref_support() {
+                            Some(obs.prob_mapping() + obs.prob_hit_base)
+                        } else {
+                            None
+                        }
+                    }).collect_vec()).exp();
+                
+                let major_rate = expected_major / expected_all;
+                expected_major > 0.0 && (major_rate - expected_major_rate).abs() < 0.05
+            } else {
+                false
             }
-        }
-        None
+        })
     }
 }

--- a/src/variants/model/bias/read_position_bias.rs
+++ b/src/variants/model/bias/read_position_bias.rs
@@ -7,16 +7,11 @@ use crate::variants::evidence::observations::read_observation::{
 };
 use crate::variants::model::bias::Bias;
 
-#[derive(Copy, Clone, PartialOrd, PartialEq, Eq, Debug, Ord, EnumIter, Hash)]
+#[derive(Copy, Clone, Default, PartialOrd, PartialEq, Eq, Debug, Ord, EnumIter, Hash)]
 pub(crate) enum ReadPositionBias {
+    #[default]
     None,
     Some,
-}
-
-impl Default for ReadPositionBias {
-    fn default() -> Self {
-        ReadPositionBias::None
-    }
 }
 
 impl Bias for ReadPositionBias {

--- a/src/variants/model/bias/read_position_bias.rs
+++ b/src/variants/model/bias/read_position_bias.rs
@@ -37,12 +37,8 @@ impl Bias for ReadPositionBias {
 
     fn prob_any(&self, observation: &ProcessedReadObservation) -> LogProb {
         match observation.read_position {
-            ReadPosition::Major => {
-                observation.prob_hit_base
-            }
-            ReadPosition::Some => {
-                observation.prob_hit_base.ln_one_minus_exp()
-            }
+            ReadPosition::Major => observation.prob_hit_base,
+            ReadPosition::Some => observation.prob_hit_base.ln_one_minus_exp(),
         }
     }
 


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced the evaluation logic for detecting homopolymer errors by requiring bidirectional indel support, resulting in more precise assessments.
	- Streamlined probability calculations for read positions to ensure consistent handling across various data scenarios.
	- Simplified method signatures and reduced complexity by eliminating unnecessary parameters and destructuring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->