### PR TITLE
perf: refactor bias/artifact computation to avoid unnecessary evaluations

### DIFF
--- a/src/calling/variants/calling.rs
+++ b/src/calling/variants/calling.rs
@@ -653,7 +653,14 @@ where
             events.push(model::Event {
                 name: "absent".to_owned(),
                 vafs: grammar::VAFTree::absent(self.n_samples()),
-                biases: vec![Artifacts::none()],
+                biases: vec![Artifacts::none(
+                    consider_read_orientation_bias,
+                    consider_strand_bias,
+                    consider_read_position_bias,
+                    consider_softclip_bias,
+                    consider_homopolymer_error,
+                    consider_alt_locus_bias,
+                )],
             });
 
             // add events from scenario
@@ -661,7 +668,14 @@ where
                 events.push(model::Event {
                     name: event_name.clone(),
                     vafs: vaftree.clone(),
-                    biases: vec![Artifacts::none()],
+                    biases: vec![Artifacts::none(
+                        consider_read_orientation_bias,
+                        consider_strand_bias,
+                        consider_read_position_bias,
+                        consider_softclip_bias,
+                        consider_homopolymer_error,
+                        consider_alt_locus_bias,
+                    )],
                 });
 
                 let biases: Vec<_> = Artifacts::all_artifact_combinations(
@@ -671,8 +685,7 @@ where
                     consider_softclip_bias,
                     consider_homopolymer_error,
                     consider_alt_locus_bias,
-                )
-                .collect();
+                );
 
                 if !biases.is_empty() {
                     // Corresponding biased event.
@@ -872,16 +885,16 @@ where
                     sample_builder.pileup(Rc::new(pileup));
                     match estimate {
                         model::likelihood::Event {
-                            artifacts: biases, ..
-                        } if biases.is_artifact() => {
+                            artifacts, ..
+                        } if artifacts.is_artifact() => {
                             sample_builder
                                 .allelefreq_estimate(AlleleFreq(0.0))
-                                .artifacts(biases.clone());
+                                .artifacts(artifacts.clone());
                         }
-                        model::likelihood::Event { allele_freq, .. } => {
+                        model::likelihood::Event { allele_freq, artifacts, .. } => {
                             sample_builder
                                 .allelefreq_estimate(*allele_freq)
-                                .artifacts(Artifacts::none());
+                                .artifacts(artifacts.clone());
                         }
                     };
 

--- a/src/variants/model/bias/alt_locus_bias.rs
+++ b/src/variants/model/bias/alt_locus_bias.rs
@@ -15,6 +15,10 @@ pub(crate) enum AltLocusBias {
 }
 
 impl Bias for AltLocusBias {
+    fn artifact_values() -> Vec<Self> {
+        vec![AltLocusBias::Some]
+    }
+
     fn prob_alt(&self, observation: &ProcessedReadObservation) -> LogProb {
         // METHOD: a read pointing to the major alt locus
         // are indicative for the variant to come from a different (distant) allele.

--- a/src/variants/model/bias/homopolymer_error.rs
+++ b/src/variants/model/bias/homopolymer_error.rs
@@ -6,7 +6,7 @@ use crate::variants::evidence::observations::pileup::Pileup;
 use crate::variants::evidence::observations::read_observation::ProcessedReadObservation;
 use crate::variants::model::bias::Bias;
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq, Default)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Default)]
 pub(crate) enum HomopolymerError {
     #[default]
     None,
@@ -20,6 +20,10 @@ impl HomopolymerError {
 }
 
 impl Bias for HomopolymerError {
+    fn artifact_values() -> Vec<Self> {
+        vec![HomopolymerError::Some]
+    }
+
     fn prob_alt(&self, observation: &ProcessedReadObservation) -> LogProb {
         match self {
             HomopolymerError::Some => observation

--- a/src/variants/model/bias/read_orientation_bias.rs
+++ b/src/variants/model/bias/read_orientation_bias.rs
@@ -15,6 +15,10 @@ pub(crate) enum ReadOrientationBias {
 }
 
 impl Bias for ReadOrientationBias {
+    fn artifact_values() -> Vec<Self> {
+        vec![ReadOrientationBias::F1R2, ReadOrientationBias::F2R1]
+    }
+
     fn prob_alt(&self, observation: &ProcessedReadObservation) -> LogProb {
         match (self, observation.read_orientation) {
             (ReadOrientationBias::None, SequenceReadPairOrientation::F1R2) => *PROB_05, // normal

--- a/src/variants/model/bias/read_position_bias.rs
+++ b/src/variants/model/bias/read_position_bias.rs
@@ -1,7 +1,5 @@
 use bio::stats::probs::LogProb;
-use bio::stats::Prob;
 use itertools::Itertools;
-use ordered_float::NotNan;
 
 use crate::variants::evidence::observations::pileup::Pileup;
 use crate::variants::evidence::observations::read_observation::{
@@ -11,23 +9,27 @@ use crate::variants::model::bias::Bias;
 
 #[derive(Copy, Clone, PartialOrd, PartialEq, Eq, Debug, Ord, EnumIter, Hash)]
 pub(crate) enum ReadPositionBias {
-    None { major_rate: Option<NotNan<f64>> },
+    None,
     Some,
 }
 
 impl Default for ReadPositionBias {
     fn default() -> Self {
-        ReadPositionBias::None { major_rate: None }
+        ReadPositionBias::None
     }
 }
 
 impl Bias for ReadPositionBias {
+    fn artifact_values() -> Vec<Self> {
+        vec![ReadPositionBias::Some]
+    }
+
     fn prob_alt(&self, observation: &ProcessedReadObservation) -> LogProb {
         match (self, observation.read_position) {
-            (ReadPositionBias::None { major_rate: _ }, ReadPosition::Major) => {
+            (ReadPositionBias::None, ReadPosition::Major) => {
                 observation.prob_hit_base
             }
-            (ReadPositionBias::None { major_rate: _ }, ReadPosition::Some) => {
+            (ReadPositionBias::None, ReadPosition::Some) => {
                 observation.prob_hit_base.ln_one_minus_exp()
             }
             (ReadPositionBias::Some, ReadPosition::Major) => LogProb::ln_one(), // bias
@@ -36,6 +38,9 @@ impl Bias for ReadPositionBias {
     }
 
     fn prob_any(&self, observation: &ProcessedReadObservation) -> LogProb {
+        // METHOD: It is important that the probability of the read position bias is
+        // is the same for both alt and ref reads in case the bias is None.
+        // Otherwise, the model can be drawn to wrong AF estimates.
         match observation.read_position {
             ReadPosition::Major => {
                 observation.prob_hit_base
@@ -47,24 +52,18 @@ impl Bias for ReadPositionBias {
     }
 
     fn is_artifact(&self) -> bool {
-        !matches!(self, ReadPositionBias::None { .. })
+        *self != ReadPositionBias::None
     }
 
     fn is_informative(&self, pileups: &[Pileup]) -> bool {
         // METHOD: if all reads overlap the variant at the major pos,
         // we cannot estimate a read position bias and None is the only informative one.
-        !self.is_artifact() || Self::estimate_major_rate(pileups).is_some()
-    }
-
-    fn learn_parameters(&mut self, pileups: &[Pileup]) {
-        if let ReadPositionBias::None { ref mut major_rate } = self {
-            *major_rate = Self::estimate_major_rate(pileups);
-        }
+        !self.is_artifact() || Self::has_valid_major_rate(pileups)
     }
 }
 
 impl ReadPositionBias {
-    fn estimate_major_rate(pileups: &[Pileup]) -> Option<NotNan<f64>> {
+    fn has_valid_major_rate(pileups: &[Pileup]) -> bool {
         let strong_all = LogProb::ln_sum_exp(
             &pileups
                 .iter()
@@ -102,16 +101,15 @@ impl ReadPositionBias {
                 .any(|obs| obs.read_position == ReadPosition::Major)
         });
 
-        if strong_all > 2.0 {
+        if strong_all >= 10.0 {
             let major_fraction = strong_major / strong_all;
-            if any_major && major_fraction < 1.0 {
-                // METHOD: if there is any read with the major read position in either
-                // the ref or the alt supporting strong evidences and not all the reads
-                // supporting ref do that at the major position, we report a fraction
-                // and consider the read position bias.
-                return Some(NotNan::new(major_fraction).unwrap());
-            }
+            // METHOD: if the major read position is rare in the ref supporting reads,
+            // we consider read position bias. Otherwise, reads are somehow
+            // all starting at the same position, e.g. caused by amplicon sequencing.
+            major_fraction < 0.1
+        } else {
+            // METHOD: not enough data to say anything, let the model decide
+            any_major
         }
-        None
     }
 }

--- a/src/variants/model/bias/softclip_bias.rs
+++ b/src/variants/model/bias/softclip_bias.rs
@@ -12,6 +12,10 @@ pub(crate) enum SoftclipBias {
 }
 
 impl Bias for SoftclipBias {
+    fn artifact_values() -> Vec<Self> {
+        vec![SoftclipBias::Some]
+    }
+
     fn prob_alt(&self, observation: &ProcessedReadObservation) -> LogProb {
         match (self, observation.softclipped) {
             (SoftclipBias::Some, true) => LogProb::ln_one(),

--- a/src/variants/model/bias/strand_bias.rs
+++ b/src/variants/model/bias/strand_bias.rs
@@ -26,6 +26,10 @@ impl Default for StrandBias {
 }
 
 impl Bias for StrandBias {
+    fn artifact_values() -> Vec<Self> {
+        vec![StrandBias::Forward, StrandBias::Reverse]
+    }
+
     fn prob_alt(&self, observation: &ProcessedReadObservation) -> LogProb {
         match (self, observation.strand) {
             (StrandBias::Forward, Strand::Forward) => LogProb::ln_one(),

--- a/src/variants/model/likelihood.rs
+++ b/src/variants/model/likelihood.rs
@@ -26,7 +26,7 @@ impl Event {
     pub(crate) fn absent() -> Self {
         Event {
             allele_freq: AlleleFreq(0.0),
-            artifacts: Artifacts::none(),
+            artifacts: Artifacts::none(false, false, false, false, false, false),
             is_discrete: true,
         }
     }
@@ -259,7 +259,7 @@ mod tests {
     use itertools_num::linspace;
 
     fn biases() -> Artifacts {
-        Artifacts::none()
+        Artifacts::none(false, false, false, false, false, false)
     }
 
     fn event(allele_freq: f64) -> Event {

--- a/src/variants/model/prior.rs
+++ b/src/variants/model/prior.rs
@@ -113,7 +113,7 @@ impl Prior {
             let sample = event.len();
             let new_event = |vaf| likelihood::Event {
                 allele_freq: vaf,
-                artifacts: Artifacts::none(),
+                artifacts: Artifacts::none(false, false, false, false, false, false),
                 is_discrete: false,
             };
 


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
