### PR TITLE
feat: add option --smart-retain-artifacts, allowing to retain artifacts instead of treating them like absent calls in smart fdr control mode

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1191,7 +1191,7 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
                 vartype,
                 minlen,
                 maxlen,
-                smart_retain_artifacts: smart_ignore_artifact,
+                smart_retain_artifacts,
             } => {
                 let events = events
                     .iter()
@@ -1218,7 +1218,7 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
                     LogProb::from(Prob::checked(fdr)?),
                     local,
                     smart,
-                    smart_ignore_artifact,
+                    smart_retain_artifacts,
                 )?;
             }
             FilterMethod::PosteriorOdds { ref events, odds } => {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -756,6 +756,16 @@ pub enum FilterMethod {
             The former behavior is much more intuitive than loosing such variants entirely."
         )]
         mode: ControlFDRMode,
+        #[structopt(
+            long,
+            help = "Whether smart mode shall ignore the artifact probability \
+            instead of taking the sum of artifact probability and \
+            absent probability for \
+            determining whether a variant shall be filtered. Setting this causes \
+            variants that are marked as artifacts to be kept.
+            "
+        )]
+        smart_ignore_artifact: bool,
         #[structopt(long, help = "Events to consider.")]
         events: Vec<String>,
         #[structopt(long, help = "Minimum indel length to consider.")]
@@ -1181,6 +1191,7 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
                 vartype,
                 minlen,
                 maxlen,
+                smart_ignore_artifact,
             } => {
                 let events = events
                     .iter()
@@ -1207,6 +1218,7 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
                     LogProb::from(Prob::checked(fdr)?),
                     local,
                     smart,
+                    smart_ignore_artifact,
                 )?;
             }
             FilterMethod::PosteriorOdds { ref events, odds } => {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -758,14 +758,14 @@ pub enum FilterMethod {
         mode: ControlFDRMode,
         #[structopt(
             long,
-            help = "Whether smart mode shall ignore the artifact probability \
+            help = "Whether smart mode shall retain artifact calls \
             instead of taking the sum of artifact probability and \
             absent probability for \
             determining whether a variant shall be filtered. Setting this causes \
             variants that are marked as artifacts to be kept.
             "
         )]
-        smart_ignore_artifact: bool,
+        smart_retain_artifacts: bool,
         #[structopt(long, help = "Events to consider.")]
         events: Vec<String>,
         #[structopt(long, help = "Minimum indel length to consider.")]
@@ -1191,7 +1191,7 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
                 vartype,
                 minlen,
                 maxlen,
-                smart_ignore_artifact,
+                smart_retain_artifacts: smart_ignore_artifact,
             } => {
                 let events = events
                     .iter()

--- a/src/filtration/fdr.rs
+++ b/src/filtration/fdr.rs
@@ -41,7 +41,7 @@ pub fn control_fdr<R, W>(
     alpha: LogProb,
     local: bool,
     smart: bool,
-    smart_ignore_artifact: bool,
+    smart_retain_artifacts: bool,
 ) -> Result<()>
 where
     R: AsRef<Path>,
@@ -95,7 +95,7 @@ where
     } else if alpha != LogProb::ln_one() {
         let dist_events = if smart {
             let mut evts = vec![SimpleEvent::new("ABSENT")];
-            if !smart_ignore_artifact {
+            if !smart_retain_artifacts {
                 evts.push(SimpleEvent::new("ARTIFACT"));
             }
             evts
@@ -151,7 +151,7 @@ where
         &cleaned_events,
         vartype,
         smart,
-        smart_ignore_artifact,
+        smart_retain_artifacts,
     )?;
 
     Ok(())

--- a/src/filtration/fdr.rs
+++ b/src/filtration/fdr.rs
@@ -41,6 +41,7 @@ pub fn control_fdr<R, W>(
     alpha: LogProb,
     local: bool,
     smart: bool,
+    smart_ignore_artifact: bool,
 ) -> Result<()>
 where
     R: AsRef<Path>,
@@ -93,7 +94,11 @@ where
         threshold = Some(alpha.ln_one_minus_exp());
     } else if alpha != LogProb::ln_one() {
         let dist_events = if smart {
-            vec![SimpleEvent::new("ABSENT"), SimpleEvent::new("ARTIFACT")]
+            let mut evts = vec![SimpleEvent::new("ABSENT")];
+            if !smart_ignore_artifact {
+                evts.push(SimpleEvent::new("ARTIFACT"));
+            }
+            evts
         } else {
             cleaned_events.clone()
         };
@@ -146,6 +151,7 @@ where
         &cleaned_events,
         vartype,
         smart,
+        smart_ignore_artifact,
     )?;
 
     Ok(())

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -292,14 +292,14 @@ pub(crate) fn filter_by_threshold<E: Event>(
     events: &[E],
     vartype: Option<&model::VariantType>,
     smart: bool,
-    smart_ignore_artifact: bool,
+    smart_retain_artifacts: bool,
 ) -> Result<()> {
     let mut breakend_event_decisions = HashMap::new();
 
     let mut tags = events_to_tags(events);
     let mut absent_and_artifact_tags = vec!["PROB_ABSENT".to_owned()];
 
-    if smart && smart_ignore_artifact {
+    if smart && smart_retain_artifacts {
         // in this case, artifact events are wanted, and hence added to the
         // queried events
         tags.push("PROB_ARTIFACT".to_owned());

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -292,11 +292,22 @@ pub(crate) fn filter_by_threshold<E: Event>(
     events: &[E],
     vartype: Option<&model::VariantType>,
     smart: bool,
+    smart_ignore_artifact: bool,
 ) -> Result<()> {
     let mut breakend_event_decisions = HashMap::new();
 
-    let tags = events_to_tags(events);
-    let absent_and_artifact_tags = ["PROB_ABSENT".to_owned(), "PROB_ARTIFACT".to_owned()];
+    let mut tags = events_to_tags(events);
+    let mut absent_and_artifact_tags = vec!["PROB_ABSENT".to_owned()];
+
+    if smart && smart_ignore_artifact {
+        // in this case, artifact events are wanted, and hence added to the
+        // queried events
+        tags.push("PROB_ARTIFACT".to_owned());
+    } else {
+        // in this case, artifacts are unwanted and hence added to the absent case
+        absent_and_artifact_tags.push("PROB_ARTIFACT".to_owned());
+    }
+
     let filter = |record: &mut bcf::Record| -> Result<Vec<bool>> {
         let bnd_event = info_tag_event(record).ok().flatten();
         let keep = if let Some(event) = bnd_event.as_ref() {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -203,6 +203,7 @@ fn control_fdr(
     alpha: f64,
     local: bool,
     smart: bool,
+    smart_retain_artifacts: bool,
     vartype: Option<&varlociraptor::variants::model::VariantType>,
 ) {
     let basedir = basedir(test);
@@ -222,6 +223,7 @@ fn control_fdr(
         LogProb::from(Prob(alpha)),
         local,
         smart,
+        smart_retain_artifacts,
     )
     .unwrap();
 }
@@ -256,6 +258,7 @@ fn test_fdr_control1() {
         0.05,
         false,
         false,
+        false,
         Some(&varlociraptor::variants::model::VariantType::Deletion(
             Some(1..30),
         )),
@@ -269,6 +272,7 @@ fn test_fdr_control2() {
         "test_fdr_ev_2",
         &["SOMATIC"],
         0.05,
+        false,
         false,
         false,
         Some(&varlociraptor::variants::model::VariantType::Deletion(
@@ -287,6 +291,7 @@ fn test_fdr_control3() {
         0.001,
         false,
         false,
+        false,
         Some(&varlociraptor::variants::model::VariantType::Deletion(
             Some(1..30),
         )),
@@ -300,6 +305,7 @@ fn test_fdr_control4() {
         "test_fdr_ev_4",
         &["SOMATIC_TUMOR"],
         0.05,
+        false,
         false,
         false,
         Some(&varlociraptor::variants::model::VariantType::Deletion(
@@ -317,6 +323,7 @@ fn test_fdr_control_local1() {
         0.05,
         true,
         false,
+        false,
         Some(&varlociraptor::variants::model::VariantType::Deletion(
             Some(1..30),
         )),
@@ -331,6 +338,7 @@ fn test_fdr_control_local2() {
         &["SOMATIC"],
         0.25,
         true,
+        false,
         false,
         Some(&varlociraptor::variants::model::VariantType::Deletion(
             Some(1..30),
@@ -347,6 +355,23 @@ fn test_fdr_control_local2_smart() {
         0.08,
         true,
         true,
+        false,
+        Some(&varlociraptor::variants::model::VariantType::Deletion(
+            Some(1..30),
+        )),
+    );
+    assert_call_number("test_fdr_local2_smart", 1);
+}
+
+#[test]
+fn test_fdr_control_local2_smart_retain_artifacts() {
+    control_fdr(
+        "test_fdr_local2_smart",
+        &["SOMATIC"],
+        0.08,
+        true,
+        true,
+        true,
         Some(&varlociraptor::variants::model::VariantType::Deletion(
             Some(1..30),
         )),
@@ -361,6 +386,7 @@ fn test_fdr_control_local3() {
         &["GERMLINE", "SOMATIC_TUMOR_LOW"],
         0.05,
         true,
+        false,
         false,
         None,
     );


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an option in smart filtering mode that gives users greater control over variant processing by allowing artifact events to be either retained or aggregated, enhancing the filtering flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->