### PR TITLE
fix: properly handle non-informative reads when dealing with strand bias (they don't prefer any option in that case).

### DIFF
--- a/src/variants/model/bias/strand_bias.rs
+++ b/src/variants/model/bias/strand_bias.rs
@@ -36,7 +36,7 @@ impl Bias for StrandBias {
             (StrandBias::Reverse, Strand::Both) => LogProb::ln_zero(),
             (StrandBias::None { .. }, Strand::Both) => observation.prob_double_overlap,
             (StrandBias::None { .. }, Strand::None) => LogProb::ln_one(), // all are none and only None is evaluated, safe to return 1
-            (_, Strand::None) => unreachable!(),
+            (_, Strand::None) => LogProb::ln_one(),
             (StrandBias::None { forward_rate }, observed) => {
                 let rate = match observed {
                     Strand::Forward => **forward_rate,


### PR DESCRIPTION
fixes #471 

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for a rare edge case, now returning a valid result rather than causing an unexpected crash.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->