### PR TITLE
Cnv candidates

### DIFF
--- a/src/candidates/cnv.rs
+++ b/src/candidates/cnv.rs
@@ -1,0 +1,85 @@
+use anyhow::{Context, Result};
+use bio_types::genome::Locus;
+use rust_htslib::bcf::header::HeaderView;
+use rust_htslib::bcf::record::{Buffer, Numeric};
+use rust_htslib::bcf::{Format, Header, Read, Reader, Record, Writer};
+use std::path::PathBuf;
+
+use crate::utils::aux_info::{self, AuxInfo, AuxInfoCollector};
+use crate::variants::model::VariantPrecision;
+use crate::variants::types::breakends::Breakend;
+
+fn create_breakend_from_record(
+    record: Record,
+    header: &HeaderView,
+    aux_info_collector: &AuxInfoCollector,
+) -> Option<Breakend> {
+    let contig =
+        String::from_utf8(header.rid2name(record.rid().unwrap()).unwrap().to_vec()).unwrap();
+
+    let mut mateid = None;
+    if let Ok(Some(values)) = record.info(b"MATEID").string() {
+        // Nimm den ersten Wert (wenn vorhanden) und kopiere ihn in einen Vec<u8>
+        mateid = values.first().map(|v| v.to_vec());
+    }
+
+    let breakend = Breakend::new(
+        Locus::new(contig, record.pos() as u64),
+        // Locus::new(header.rid2name(record.rid())?, record.pos() as u64),
+        record.alleles()[0],
+        record.alleles()[1],
+        &record.id(),
+        mateid,
+        VariantPrecision::Precise,
+        aux_info_collector.collect(&record).unwrap(),
+    )
+    .unwrap();
+    dbg!(&breakend);
+    breakend
+}
+
+pub fn find_candidates(breakends_bcf: PathBuf, outbcf: Option<PathBuf>) -> Result<()> {
+    let bcf_reader = Reader::from_path(breakends_bcf.clone()).expect("Error opening input file.");
+    let mut header = Header::new();
+    let aux_info_collector = AuxInfoCollector::new(&[], &bcf_reader).unwrap();
+    let headerview = bcf_reader.header();
+    // TODO: I create it 2 time because of ownership issues
+    let mut bcf_reader = Reader::from_path(breakends_bcf).expect("Error opening input file.");
+
+    // TODO: Find contig from old file
+    let header_contig_line = format!(r#"##contig=<ID={}>"#, "J02459");
+    header.push_record(header_contig_line.as_bytes());
+
+    let mut bcf_writer: Writer;
+    match outbcf {
+        Some(path) => {
+            bcf_writer = Writer::from_path(path, &header, true, Format::Bcf)
+                .with_context(|| "Error opening BCF writer".to_string())?;
+        }
+        None => {
+            bcf_writer = Writer::from_stdout(&header, true, Format::Bcf)
+                .with_context(|| "Error opening BCF writer".to_string())?;
+        }
+    }
+
+    // Wir gehen direkt durch alle Datensätze und verändern sie on-the-fly
+    for record_result in bcf_reader.records() {
+        let record = record_result.expect("Error reading record");
+        let mut cnv_record = bcf_writer.empty_record();
+
+        cnv_record.set_rid(record.rid());
+        cnv_record.set_pos(record.pos());
+        cnv_record.set_qual(f32::missing());
+
+        let old_allele = record.alleles()[0].to_vec();
+        cnv_record.set_alleles(&[old_allele.as_slice(), b"<CNV>"])?;
+
+        let breakend = create_breakend_from_record(record, headerview, &aux_info_collector);
+        // TODO: Filter on breakends to use only csv positions
+        bcf_writer
+            .write(&cnv_record)
+            .with_context(|| "Failed to write modified BCF record".to_string())?;
+    }
+
+    Ok(())
+}

--- a/src/candidates/cnv.rs
+++ b/src/candidates/cnv.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use bio_types::genome::{AbstractLocus, Locus};
 use rust_htslib::bcf::header::HeaderView;
+use rust_htslib::bcf::record::Numeric;
 use rust_htslib::bcf::{Format, Header, Read, Reader, Record, Writer};
 use std::path::PathBuf;
 
@@ -8,11 +9,27 @@ use crate::utils::aux_info::AuxInfoCollector;
 use crate::variants::model::VariantPrecision;
 use crate::variants::types::breakends::Breakend;
 
-/// GRIDSS calculates quality scores according to the model outlined in the paper.
-/// As GRIDSS does not yet perform multiple test correction or score recalibration, QUAL scores are vastly overestimated for all variants.
-/// As a rule of thumb, variants that have QUAL >= 1000 and have assemblies from both sides of the breakpoint (AS > 0 & RAS > 0) are considered of high quality,
-/// variants with QUAL >= 500 but that can only be assembled from one breakend (AS > 0 | RAS > 0) are considered of intermediate quality,
-/// and variants with low QUAL score or lack any supporting assemblies are considered to be of low quality.
+/// Builds a new BCF header based on the input header
+fn create_header_from_existing(existing: &HeaderView) -> Result<Header> {
+    let mut header = Header::new();
+
+    for rid in 0..existing.contig_count() {
+        let name =
+            std::str::from_utf8(existing.rid2name(rid)?).context("Invalid UTF-8 in contig name")?;
+        let header_contig_line = format!(r#"##contig=<ID={}>"#, name);
+        header.push_record(header_contig_line.as_bytes());
+    }
+
+    header.push_record(
+        b"##INFO=<ID=QUAL,Number=1,Type=String,Description=\"Variant classification\">",
+    );
+    header.push_record(
+        b"##INFO=<ID=ENDING,Number=1,Type=String,Description=\"Ending position of breakend\">",
+    );
+
+    Ok(header)
+}
+
 fn create_breakend_from_record(
     record: &Record,
     header: &HeaderView,
@@ -60,9 +77,14 @@ fn create_record(record: &Record, bcf_writer: &Writer, breakend: Breakend) -> Re
     let old_allele = record.alleles()[0].to_vec();
     cnv_record.set_alleles(&[old_allele.as_slice(), b"<CNV>"])?;
 
+    // GRIDSS calculates quality scores according to the model outlined in the paper.
+    // As GRIDSS does not yet perform multiple test correction or score recalibration, QUAL scores are vastly overestimated for all variants.
+    // As a rule of thumb, variants that have QUAL >= 1000 and have assemblies from both sides of the breakpoint (AS > 0 & RAS > 0) are considered of high quality,
+    // variants with QUAL >= 500 but that can only be assembled from one breakend (AS > 0 | RAS > 0) are considered of intermediate quality,
+    // and variants with low QUAL score or lack any supporting assemblies are considered to be of low quality.
     let as_val = get_first_info_int(record, b"AS");
     let ras_val = get_first_info_int(record, b"RAS");
-
+    cnv_record.set_qual(f32::missing());
     let gridss_qual = match (as_val, ras_val) {
         (Some(1), Some(1)) if record.qual() > 1000.0 => "HIGH",
         (Some(1), _) | (_, Some(1)) if record.qual() > 500.0 => "MEDIUM",
@@ -71,35 +93,16 @@ fn create_record(record: &Record, bcf_writer: &Writer, breakend: Breakend) -> Re
     cnv_record
         .push_info_string(b"QUAL", &[gridss_qual.as_bytes()])
         .with_context(|| "Failed to push QUAL info string")?;
-    let mate_locus = breakend.join().as_ref().unwrap().locus();
+
+    let join = breakend.join().as_ref().unwrap();
+    let mate_locus = join.locus();
     let end_value = format!("{}:{}", mate_locus.contig(), mate_locus.pos());
     let end = end_value.as_str();
     cnv_record
-        .push_info_string(b"END", &[end.as_bytes()])
+        .push_info_string(b"ENDING", &[end.as_bytes()])
         .with_context(|| "Failed to push END info string")?;
 
     Ok(cnv_record)
-}
-
-/// Builds a new BCF header based on the input header
-fn create_header_from_existing(existing: &HeaderView) -> Result<Header> {
-    let mut header = Header::new();
-
-    for rid in 0..existing.contig_count() {
-        let name =
-            std::str::from_utf8(existing.rid2name(rid)?).context("Invalid UTF-8 in contig name")?;
-        let header_contig_line = format!(r#"##contig=<ID={}>"#, name);
-        header.push_record(header_contig_line.as_bytes());
-    }
-
-    header.push_record(
-        b"##INFO=<ID=QUAL,Number=1,Type=String,Description=\"Variant classification\">",
-    );
-    header.push_record(
-        b"##INFO=<ID=END,Number=1,Type=String,Description=\"Ending position of breakend\">",
-    );
-
-    Ok(header)
 }
 
 /// Reads an input BCF file, processes each record, and writes out modified CNV records

--- a/src/candidates/mod.rs
+++ b/src/candidates/mod.rs
@@ -1,1 +1,2 @@
+pub mod cnv;
 pub mod methylation;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -125,6 +125,23 @@ pub enum Varlociraptor {
         #[structopt(name = "output", parse(from_os_str), help = "Output BCF File")]
         output: Option<PathBuf>,
     },
+    #[structopt(
+        name = "cnv-candidates",
+        about = "Generate BCF with cnv candidates",
+        usage = "varlociraptor cnv-candidates input.breakends (gridss output) output.bcf"
+    )]
+    CNVCandidates {
+        #[structopt(
+            name = "input",
+            parse(from_os_str),
+            required = true,
+            help = "Input breakends File"
+        )]
+        input: PathBuf,
+
+        #[structopt(name = "output", parse(from_os_str), help = "Output BCF File")]
+        output: Option<PathBuf>,
+    },
 }
 
 pub struct PreprocessInput {
@@ -1344,6 +1361,9 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
         },
         Varlociraptor::MethylationCandidates { input, output } => {
             candidates::methylation::find_candidates(input, output)?;
+        }
+        Varlociraptor::CNVCandidates { input, output } => {
+            candidates::cnv::find_candidates(input, output)?;
         }
     }
     Ok(())

--- a/src/variants/types/breakends.rs
+++ b/src/variants/types/breakends.rs
@@ -1199,8 +1199,9 @@ impl ExtensionModification {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, new)]
+#[derive(Debug, Clone, PartialEq, Getters, Eq, new)]
 pub(crate) struct Join {
+    #[get = "pub(crate)"]
     locus: genome::Locus,
     side: Side,
     extension_modification: ExtensionModification,


### PR DESCRIPTION
### Description

Add support for creating a candidate vcf file of breakends for cnv. Adds support for cl invokes and transformation from gridss breakend output to standard varlociraptor vcf input.



I did not do this yet:
### QC

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
