### PR TITLE
fix: fixed handling of read position information when merging read pairs

### DIFF
--- a/src/variants/types/mod.rs
+++ b/src/variants/types/mod.rs
@@ -102,7 +102,7 @@ impl AlleleSupport {
     pub(crate) fn merge(&mut self, other: &AlleleSupport) -> &mut Self {
         if self.is_alt_support() {
             if other.is_alt_support() {
-                // METHOD: both reads support the alt allele, but if they both do 
+                // METHOD: both reads support the alt allele, but if they both do
                 // at different positions this speaks against read position bias,
                 // hence setting the read position to None.
                 if self.read_position != other.read_position {

--- a/src/variants/types/mod.rs
+++ b/src/variants/types/mod.rs
@@ -105,6 +105,7 @@ impl AlleleSupport {
                 // METHOD: both reads support the alt allele, but if they both do
                 // at different positions this speaks against read position bias,
                 // hence setting the read position to None.
+                // If both values are None, self.read_position remains None as well.
                 if self.read_position != other.read_position {
                     self.read_position = None;
                 }


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the logic for merging allele support information, resulting in more accurate handling of read position data when assessing alternate allele support. No changes to visible features or user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->