### PR TITLE
fix: consider leading hardclips when calculating read position

### DIFF
--- a/src/variants/types/mnv.rs
+++ b/src/variants/types/mnv.rs
@@ -124,7 +124,7 @@ impl<R: Realigner> Mnv<R> {
                         // of the original read sequence. Hence, they have to be added
                         // here.
                         read_position =
-                            Some(qpos + read.cigar_cached().unwrap().leading_hardclips());
+                            Some(qpos + read.cigar_cached().unwrap().leading_hardclips() as u32);
                     }
                     let read_base = unsafe { read.seq().decoded_base_unchecked(qpos as usize) }
                         .to_ascii_uppercase();

--- a/src/variants/types/mnv.rs
+++ b/src/variants/types/mnv.rs
@@ -120,7 +120,11 @@ impl<R: Realigner> Mnv<R> {
                 {
                     if read_position.is_none() {
                         // set first MNV position as read position
-                        read_position = Some(qpos);
+                        // METHOD: hardclips are not part of qpos, but they are part
+                        // of the original read sequence. Hence, they have to be added
+                        // here.
+                        read_position =
+                            Some(qpos + read.cigar_cached().unwrap().leading_hardclips());
                     }
                     let read_base = unsafe { read.seq().decoded_base_unchecked(qpos as usize) }
                         .to_ascii_uppercase();

--- a/src/variants/types/snv.rs
+++ b/src/variants/types/snv.rs
@@ -127,7 +127,12 @@ impl<R: Realigner> Snv<R> {
                     .prob_ref_allele(prob_ref)
                     .prob_alt_allele(prob_alt)
                     .strand(strand)
-                    .read_position(Some(qpos))
+                    // METHOD: hardclips are not part of qpos, but they are part
+                    // of the original read sequence. Hence, they have to be added
+                    // here.
+                    .read_position(Some(
+                        qpos + read.cigar_cached().unwrap().leading_hardclips() as u32,
+                    ))
                     .third_allele_evidence(if is_third_allele {
                         Some(EditDistance(1))
                     } else {


### PR DESCRIPTION

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the calculation of read positions for variant reporting to accurately include leading hard-clipped bases from sequencing reads. This ensures that read positions now reflect the original coordinates, improving the accuracy of variant annotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->