### PR TITLE
CNV alignment properties

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,18 @@
 [package]
-authors = ["Johannes Köster <johannes.koester@tu-dortmund.de>", "David Lähnemann <david.laehnemann@uni-duesseldorf.de>"]
+authors = [
+    "Johannes Köster <johannes.koester@tu-dortmund.de>",
+    "David Lähnemann <david.laehnemann@uni-duesseldorf.de>",
+]
 description = "A library for calling of genomic variants using a latent variable model."
 edition = "2018"
-include = ["src/**/*", "Cargo.toml", "CHANGELOG.md", "README.md", "LICENSE", "templates/*"]
+include = [
+    "src/**/*",
+    "Cargo.toml",
+    "CHANGELOG.md",
+    "README.md",
+    "LICENSE",
+    "templates/*",
+]
 license = "GPL-3.0"
 name = "varlociraptor"
 readme = "README.md"
@@ -61,7 +71,7 @@ serde_yaml = ">=0.8.4,<0.9"
 shrinkwraprs = "0.3.0"
 statrs = "0.18"
 structopt = "0.3"
-strum = ">= 0.16, < 0.27" # Needs to be in sync with rust-bios strum dependency
+strum = ">= 0.16, < 0.27"                                             # Needs to be in sync with rust-bios strum dependency
 strum_macros = ">= 0.16, < 0.27"
 tempfile = "3"
 thiserror = "1.0"
@@ -71,6 +81,7 @@ uuid = { version = "0.8", features = ["v4"] }
 vec_map = "0.8"
 yaml-rust = ">=0.4.1,<0.5"
 linear-map = "1.2"
+intervaltree = "0.2"
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/src/candidates/cnv.rs
+++ b/src/candidates/cnv.rs
@@ -42,7 +42,13 @@ fn write_records(intervals: Vec<Interval>, header: &Header, outbcf: Option<PathB
         cnv_record.set_pos(interval.start as i64);
         cnv_record.set_qual(f32::NAN);
         cnv_record.set_alleles(&[b"<CNV>"])?;
-        cnv_record.push_info_integer(b"END", &[interval.end])?;
+        // TODO: Get the chromosome dynamically
+        let end_value = format!("{}:{}", "J02459", interval.end);
+        let end = end_value.as_str();
+        cnv_record
+            .push_info_string(b"ENDING", &[end.as_bytes()])
+            .with_context(|| "Failed to push END info string")?;
+
         cnv_record.push_info_string(b"CNVTYPE", &[cnv_type])?;
 
         bcf_writer
@@ -65,9 +71,8 @@ fn create_header_from_existing(existing: &HeaderView) -> Result<Header> {
 
     header.push_record(b"##INFO=<ID=CNVTYPE,Number=1,Type=String,Description=\"Type of CNV\">");
     header.push_record(
-        b"##INFO=<ID=END,Number=1,Type=Integer,Description=\"Ending position of breakend\">",
+        b"##INFO=<ID=ENDING,Number=1,Type=String,Description=\"Ending position of breakend\">",
     );
-
     Ok(header)
 }
 

--- a/src/candidates/cnv.rs
+++ b/src/candidates/cnv.rs
@@ -57,7 +57,6 @@ fn create_breakend_from_record(
 
 /// Helper function to extract the first integer value from an INFO field
 fn get_first_info_int(record: &Record, tag: &[u8]) -> Option<i32> {
-    print!("Test");
     record
         .info(tag)
         .integer()

--- a/src/candidates/cnv.rs
+++ b/src/candidates/cnv.rs
@@ -57,6 +57,7 @@ fn create_breakend_from_record(
 
 /// Helper function to extract the first integer value from an INFO field
 fn get_first_info_int(record: &Record, tag: &[u8]) -> Option<i32> {
+    print!("Test");
     record
         .info(tag)
         .integer()

--- a/src/candidates/cnv.rs
+++ b/src/candidates/cnv.rs
@@ -9,7 +9,7 @@ use crate::utils::aux_info::AuxInfoCollector;
 use crate::variants::model::VariantPrecision;
 use crate::variants::types::breakends::Breakend;
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Interval {
     pub start: i32,
     pub end: i32,
@@ -106,26 +106,21 @@ fn breakends_to_intervals(breakends: Vec<Breakend>) -> Vec<Interval> {
     let mut deltas = BTreeMap::new();
     for b in breakends {
         if let Some(join) = b.join() {
-            let start = b.locus().pos() as usize;
-            let end = join.locus().pos() as usize;
-
-            if start < end {
-                *deltas.entry(start).or_insert(0) += 1;
-                *deltas.entry(end).or_insert(0) -= 1;
-            } else if start > end {
-                *deltas.entry(end).or_insert(0) -= 1;
-                *deltas.entry(start).or_insert(0) += 1;
-            }
+            let start = b.locus().pos() as i32;
+            let end = join.locus().pos() as i32;
+            dbg!(&start, &end);
+            *deltas.entry(start).or_insert(0) += 1;
+            *deltas.entry(end).or_insert(0) -= 1;
         }
     }
     // Compute intervals from borders
     let mut intervals_deltas = Vec::new();
-    let mut last_pos = 0;
+    let mut last_pos = -1;
     let mut current_cov = 0;
 
     for (&pos, &delta) in deltas.iter() {
-        if last_pos != 0 && last_pos < pos && current_cov != 0 {
-            intervals_deltas.push(Interval::new(last_pos as i32, pos as i32, current_cov));
+        if last_pos != -1 && last_pos < pos && current_cov != 0 {
+            intervals_deltas.push(Interval::new(last_pos, pos, current_cov));
         }
         current_cov += delta;
         last_pos = pos;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -428,11 +428,11 @@ pub enum EstimateKind {
 
         #[structopt(
             long,
-            help = "VCF file listing known copy number variants (CNVs). \
+            help = "BCF file listing known copy number variants (CNVs). \
             Typically generated via the GRIDSS tool and the `varlociraptor cnv-candidates` subcommand. \
             This is essential for estimating baseline coverage in non-CNV regions."
         )]
-        vcf: PathBuf,
+        bcf: Option<PathBuf>,
 
         #[structopt(long, help = "Number of records to sample from the BAM file")]
         num_records: Option<usize>,
@@ -1307,11 +1307,13 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
             EstimateKind::AlignmentProperties {
                 reference,
                 bams,
+                bcf,
                 num_records,
             } => {
                 let mut reference_buffer = reference::Buffer::from_path(&reference, 1)?;
                 let alignment_properties = estimate_alignment_properties(
                     &bams,
+                    bcf,
                     false,
                     &mut reference_buffer,
                     num_records,
@@ -1389,6 +1391,12 @@ pub(crate) fn est_or_load_alignment_properties(
             alignment_properties_file,
         )?)?)
     } else {
-        estimate_alignment_properties(&[bam_file], omit_insert_size, reference_buffer, num_records)
+        estimate_alignment_properties(
+            &[bam_file],
+            None,
+            omit_insert_size,
+            reference_buffer,
+            num_records,
+        )
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -426,6 +426,14 @@ pub enum EstimateKind {
         )]
         bams: Vec<PathBuf>,
 
+        #[structopt(
+            long,
+            help = "VCF file listing known copy number variants (CNVs). \
+            Typically generated via the GRIDSS tool and the `varlociraptor cnv-candidates` subcommand. \
+            This is essential for estimating baseline coverage in non-CNV regions."
+        )]
+        vcf: PathBuf,
+
         #[structopt(long, help = "Number of records to sample from the BAM file")]
         num_records: Option<usize>,
     },

--- a/src/estimation/alignment_properties.rs
+++ b/src/estimation/alignment_properties.rs
@@ -233,15 +233,15 @@ impl AlignmentProperties {
             for result in bcf.records() {
                 let record = result.with_context(|| "Error reading record")?;
                 let pos = record.pos() as u64;
-                let ending = record
-                    .info(b"ENDING")
+                let end_pos = record
+                    .info(b"ENDPOS")
                     .string()
-                    .with_context(|| "Missing or malformed ENDING field in record")?;
+                    .with_context(|| "Missing or malformed ENDPOS field in record")?;
 
-                if let Some(ending_vec) = ending {
-                    if let Some(ending_bytes) = ending_vec.first() {
-                        let ending_str = std::str::from_utf8(ending_bytes)?;
-                        if let Some((_, end_pos_str)) = ending_str.split_once(':') {
+                if let Some(end_vec) = end_pos {
+                    if let Some(end_bytes) = end_vec.first() {
+                        let end_str = std::str::from_utf8(end_bytes)?;
+                        if let Some((_, end_pos_str)) = end_str.split_once(':') {
                             let end_pos = end_pos_str.parse::<u64>()?;
                             intervals.push((pos..end_pos, ()));
                         }

--- a/src/estimation/alignment_properties.rs
+++ b/src/estimation/alignment_properties.rs
@@ -146,7 +146,8 @@ impl AlignmentProperties {
     /// Estimate `AlignmentProperties` from first NUM_FRAGMENTS fragments of bam file.
     /// Only reads that are mapped, not duplicates and where quality checks passed are taken.
     pub(crate) fn estimate(
-        paths: &[impl AsRef<Path>],
+        bam_paths: &[impl AsRef<Path>],
+        bcf_path: Option<impl AsRef<Path>>,
         omit_insert_size: bool,
         reference_buffer: &mut reference::Buffer,
         num_records: Option<usize>,
@@ -218,7 +219,7 @@ impl AlignmentProperties {
         // Use this to estimate the number of alignments needed to estimate the
         // HPHMM's transition probabilities to a certain precision.
         let num_alignments = {
-            let ns = paths
+            let ns = bam_paths
                 .iter()
                 .map(|path| -> Result<u64> {
                     let mut bam = bam::IndexedReader::from_path(path.as_ref())?;
@@ -233,7 +234,7 @@ impl AlignmentProperties {
         };
 
         // FIXME: reset fp/reader in rust-htslib after index_stats call
-        let mut bams = paths
+        let mut bams = bam_paths
             .iter()
             .map(|path| Ok(bam::IndexedReader::from_path(path.as_ref())?))
             .collect::<Result<Vec<_>>>()?;
@@ -1068,6 +1069,7 @@ mod tests {
 
         let props = AlignmentProperties::estimate(
             &[path, path],
+            None::<&Path>,
             false,
             &mut reference_buffer,
             Some(NUM_FRAGMENTS),
@@ -1093,6 +1095,7 @@ mod tests {
 
         let props = AlignmentProperties::estimate(
             &[path],
+            None::<&Path>,
             false,
             &mut reference_buffer,
             Some(NUM_FRAGMENTS),
@@ -1114,6 +1117,7 @@ mod tests {
 
         let props = AlignmentProperties::estimate(
             &[path],
+            None::<&Path>,
             false,
             &mut reference_buffer,
             Some(NUM_FRAGMENTS),

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -54,4 +54,9 @@ impl Buffer {
             Ok(Arc::clone(sequences.get(chrom).unwrap()))
         }
     }
+
+    pub(crate) fn total_reference_length(&self) -> u64 {
+        let reader = self.reader.read().unwrap();
+        reader.index.sequences().iter().map(|seq| seq.len).sum()
+    }
 }

--- a/src/testcase/builder.rs
+++ b/src/testcase/builder.rs
@@ -361,6 +361,7 @@ impl Testcase {
         for (name, path) in &self.bams {
             let properties = sample::estimate_alignment_properties(
                 &[path],
+                None,
                 false,
                 &mut self.reference_buffer,
                 Some(crate::estimation::alignment_properties::NUM_FRAGMENTS),

--- a/src/variants/sample.rs
+++ b/src/variants/sample.rs
@@ -140,13 +140,15 @@ impl SubsampleCandidates {
 }
 
 pub(crate) fn estimate_alignment_properties<P: AsRef<Path>>(
-    paths: &[P],
+    bam_paths: &[P],
+    bcf_path: Option<P>,
     omit_insert_size: bool,
     reference_buffer: &mut reference::Buffer,
     num_records: Option<usize>,
 ) -> Result<alignment_properties::AlignmentProperties> {
     alignment_properties::AlignmentProperties::estimate(
-        paths,
+        bam_paths,
+        bcf_path,
         omit_insert_size,
         reference_buffer,
         num_records,


### PR DESCRIPTION
### Description

This pull request adds support for calculating and storing average depth and average depth per CG ratio in the alignment properties. These metrics are computed based only on genomic regions that are not affected by copy number variations (CNVs). To enable this, users can optionally provide a BCF file containing CNV candidate regions. 

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
