### PR TITLE
feat: allow outputting mutational burden as TSV table

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -460,8 +460,10 @@ pub enum EstimateKind {
         about = "Estimate mutational burden. Takes Varlociraptor calls (must be annotated \
                  with e.g. VEP but using ANN instead of CSQ) from STDIN, prints mutational burden estimate in Vega-lite JSON format to STDOUT. \
                  It can be converted to an image via vega-lite-cli (see conda package).",
-        usage = "varlociraptor estimate mutational-burden --coding-genome-size 3e7 --events SOMATIC_TUMOR \
-                 --sample tumor < calls.bcf | vg2svg > tmb.svg",
+        usage = "varlociraptor estimate mutational-burden --mode curve --coding-genome-size 3e7 --events SOMATIC_TUMOR \
+                 --sample tumor < calls.bcf | vg2svg > tmb.svg\n    \
+                 varlociraptor estimate mutational-burden --mode table --coding-genome-size 3e7 --events SOMATIC_TUMOR \
+                 --sample tumor < calls.bcf | vg2svg > tmb.tsv",
         setting = structopt::clap::AppSettings::ColoredHelp,
     )]
     MutationalBurden {
@@ -479,11 +481,11 @@ pub enum EstimateKind {
         )]
         coding_genome_size: f64,
         #[structopt(
-            long = "plot-mode",
-            possible_values = &estimation::mutational_burden::PlotMode::iter().map(|v| v.into()).collect_vec(),
-            help = "How to plot (as stratified curve, histogram or multi-sample barplot)."
+            long = "mode",
+            possible_values = &estimation::mutational_burden::Mode::iter().map(|v| v.into()).collect_vec(),
+            help = "How to output to STDOUT (as stratified curve, histogram, or multi-sample barplot, or TSV table)."
         )]
-        mode: estimation::mutational_burden::PlotMode,
+        mode: estimation::mutational_burden::Mode,
         #[structopt(
             long = "vaf-cutoff",
             default_value = "0.2",
@@ -570,9 +572,7 @@ pub enum CallKind {
         #[structopt(
             long = "testcase-locus",
             help = "Create a test case for the given locus. Locus must be given in the form \
-                    CHROM:POS[:IDX]. IDX is thereby an optional value to select a particular \
-                    variant at the locus, counting from 1. If IDX is not specified, the first \
-                    variant will be chosen. Alternatively, for single variant VCFs, you can \
+                    CHROM:POS. Alternatively, for single variant VCFs, you can \
                     specify 'all'."
         )]
         testcase_locus: Option<String>,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -15,10 +15,6 @@ pub(crate) enum Error {
     InvalidInheritanceSampleName { name: String },
     #[error("observation files must be provided as samplename=path")]
     InvalidObservationsSpec,
-    #[error(
-        "invalid variant index given, must be not higher than the number of variants at the locus"
-    )]
-    InvalidIndex,
     #[error("invalid locus for --testcase-locus. Use CHROM:POS syntax")]
     InvalidLocus,
     #[error("no candidate variant at the given locus")]

--- a/src/estimation/alignment_properties.rs
+++ b/src/estimation/alignment_properties.rs
@@ -191,14 +191,6 @@ impl AlignmentProperties {
             }
         }
 
-        struct RecordStats {
-            mapq: u8,
-            read_len: u32,
-            cigar_counts: CigarStats,
-            transition_counts: TransitionCounts,
-            insert_size: Option<f64>,
-        }
-
         #[derive(Default, Debug)]
         struct AlignmentStats {
             n_reads: usize,

--- a/src/testcase/builder.rs
+++ b/src/testcase/builder.rs
@@ -27,7 +27,7 @@ use crate::{cli, reference};
 
 lazy_static! {
     static ref TESTCASE_RE: Regex =
-        Regex::new(r"^(?P<chrom>[^:]+):(?P<pos>\d+)(:(?P<idx>\d+))?$").unwrap();
+        Regex::new(r"^(?P<chrom>[^:]+):(?P<pos>\d+)$").unwrap();
 }
 
 lazy_static! {
@@ -67,8 +67,6 @@ pub struct Testcase {
     chrom_name: Option<Vec<u8>>,
     #[builder(private)]
     pos: Option<u64>,
-    #[builder(private)]
-    idx: usize,
     #[builder(private)]
     reference_buffer: reference::Buffer,
     candidates: PathBuf,
@@ -112,7 +110,7 @@ impl TestcaseBuilder {
 
     pub(crate) fn locus(self, locus: &str) -> Result<Self> {
         if locus == "all" {
-            Ok(self.chrom_name(None).pos(None).idx(0))
+            Ok(self.chrom_name(None).pos(None))
         } else if let Some(captures) = TESTCASE_RE.captures(locus) {
             let chrom_name = captures
                 .name("chrom")
@@ -122,14 +120,8 @@ impl TestcaseBuilder {
                 .to_owned();
             let mut pos: u64 = captures.name("pos").unwrap().as_str().parse()?;
             pos -= 1;
-            let idx = if let Some(m) = captures.name("idx") {
-                let idx: usize = m.as_str().parse()?;
-                idx - 1
-            } else {
-                0
-            };
 
-            Ok(self.chrom_name(Some(chrom_name)).pos(Some(pos)).idx(idx))
+            Ok(self.chrom_name(Some(chrom_name)).pos(Some(pos)))
         } else {
             Err(errors::Error::InvalidLocus.into())
         }

--- a/src/utils/log2_fold_change.rs
+++ b/src/utils/log2_fold_change.rs
@@ -1,6 +1,5 @@
 use std::ops::Not;
 
-use num_traits::ops;
 use ordered_float::NotNan;
 
 use crate::{

--- a/src/utils/variant_buffer.rs
+++ b/src/utils/variant_buffer.rs
@@ -55,7 +55,7 @@ impl VariantBuffer {
         }
     }
 
-    pub(crate) fn next(&mut self) -> Result<Option<Variants>> {
+    pub(crate) fn next(&mut self) -> Result<Option<Variants<'_>>> {
         if self.skips.total_count() > 0 && self.skips.total_count() % 100 == 0 {
             self.display_skips();
         }

--- a/src/variants/evidence/observations/read_observation.rs
+++ b/src/variants/evidence/observations/read_observation.rs
@@ -815,14 +815,12 @@ impl Hash for Evidence {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub(crate) enum EvidenceIdentifier {
     Bytes(Vec<u8>),
-    Integer(u32),
 }
 
 impl std::fmt::Display for EvidenceIdentifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             EvidenceIdentifier::Bytes(id) => write!(f, "{}", str::from_utf8(id).unwrap()),
-            EvidenceIdentifier::Integer(id) => write!(f, "{}", id),
         }
     }
 }
@@ -831,7 +829,6 @@ impl Hash for EvidenceIdentifier {
     fn hash<H: Hasher>(&self, state: &mut H) {
         match self {
             EvidenceIdentifier::Bytes(id) => id.hash(state),
-            EvidenceIdentifier::Integer(id) => id.hash(state),
         }
     }
 }

--- a/src/variants/model/mod.rs
+++ b/src/variants/model/mod.rs
@@ -3,10 +3,9 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::cmp::Ordering;
 use std::convert::TryFrom;
 use std::fmt::{self, Debug};
-use std::ops::{Deref, Range, RangeInclusive};
+use std::ops::{Range, RangeInclusive};
 use std::str;
 
 use anyhow::{bail, Result};
@@ -78,65 +77,6 @@ pub(crate) fn AlleleFreq(af: f64) -> AlleleFreq {
 //         &self.inner
 //     }
 // }
-
-/// An allele frequency range
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct ContinuousAlleleFreqs {
-    inner: Range<AlleleFreq>,
-    pub(crate) left_exclusive: bool,
-    pub(crate) right_exclusive: bool,
-    /// offset to add when calculating the smallest observable value for a left-exclusive 0.0 bound
-    zero_offset: NotNan<f64>,
-}
-
-impl ContinuousAlleleFreqs {
-    pub(crate) fn absent() -> Self {
-        Self::singleton(0.0)
-    }
-
-    pub(crate) fn singleton(value: f64) -> Self {
-        ContinuousAlleleFreqs {
-            inner: AlleleFreq(value)..AlleleFreq(value),
-            left_exclusive: false,
-            right_exclusive: false,
-            zero_offset: NotNan::from(1.0_f64),
-        }
-    }
-
-    // TODO maybe use this where appropriate
-    // pub(crate) fn is_singleton(&self) -> bool {
-    //     self.start == self.end
-    // }
-}
-
-impl Default for ContinuousAlleleFreqs {
-    fn default() -> Self {
-        Self::absent()
-    }
-}
-
-impl Ord for ContinuousAlleleFreqs {
-    fn cmp(&self, other: &Self) -> Ordering {
-        match self.inner.start.cmp(&other.start) {
-            Ordering::Equal => self.inner.end.cmp(&other.end),
-            ord => ord,
-        }
-    }
-}
-
-impl PartialOrd for ContinuousAlleleFreqs {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Deref for ContinuousAlleleFreqs {
-    type Target = Range<AlleleFreq>;
-
-    fn deref(&self) -> &Range<AlleleFreq> {
-        &self.inner
-    }
-}
 
 #[derive(Hash, Debug, Eq, PartialEq, Clone)]
 pub enum HaplotypeIdentifier {

--- a/src/variants/model/modes/generic.rs
+++ b/src/variants/model/modes/generic.rs
@@ -133,7 +133,7 @@ impl LikelihoodOperands {
         self.events.insert(self.events.len(), event);
     }
 
-    pub(crate) fn iter(&self) -> Values<Event> {
+    pub(crate) fn iter(&self) -> Values<'_, Event> {
         self.events.values()
     }
 


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).
