### PR TITLE
fix: always report non-zero edit dist against alt allele if it exceeds the edit dist against the ref allele

### DIFF
--- a/src/calling/variants/calling.rs
+++ b/src/calling/variants/calling.rs
@@ -177,8 +177,9 @@ where
               The second letter denotes an extended Kass Raftery score: N=none, E=equal, B=barely, P=positive, S=strong, V=very strong (lower case if \
               probability for correct mapping of fragment is <95%). Note that we extend Kass Raftery scores with \
               a term for equality between the evidence of the two alleles (E=equal). \
-              D denotes the edit distance to the ALT allele in case it is higher than what could be expected from sequencing errors \
-              (in that case, Varlociraptor derives a third allele from the read sequence and considers that as an alternative \
+              D denotes the edit distance to the ALT allele \
+              (if it is higher than expected from the sequencing error rates, \
+              Varlociraptor derives a third allele from the read sequence and considers that as an alternative \
               to the alt allele, instead of the reference allele), \
               T being the type of alignment, encoded \
               as s=single end and p=paired end, A denoting whether the observations also map to an alternative locus \

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -439,7 +439,7 @@ pub enum EstimateKind {
             help = "BAM files with aligned reads from a single sample or a set of \
             samples that have been sequenced and prepared in exactly the same way. \
             Use multiple BAM files in order to increase estimation robustness in case \
-            the samples only have comparably reads (e.g. in case of panel sequencing)."
+            the samples only have comparably few reads (e.g. in case of panel sequencing)."
         )]
         bams: Vec<PathBuf>,
 
@@ -877,7 +877,7 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
                     if realignment_window > (128 / 2) {
                         return Err(
                             structopt::clap::Error::with_description(
-                                "Command-line option --indel-window requires a value <= 64 with the current implementation.", 
+                                "Command-line option --indel-window requires a value <= 64 with the current implementation.",
                                 structopt::clap::ErrorKind::ValueValidation
                             ).into()
                         );
@@ -979,6 +979,16 @@ pub fn run(opt: Varlociraptor) -> Result<()> {
                             processor.process()?;
                         }
                         "exact" => {
+                            if Prob::from(gap_params.prob_deletion_extend_artifact) > Prob(0.3)
+                                || Prob::from(gap_params.prob_insertion_extend_artifact) > Prob(0.3)
+                            {
+                                warn!(
+                                    "Unexpectedly high prob_deletion_extend_artifact or \
+                                    prob_insertion_extend_artifact in alignment properties (>30%). \
+                                    Consider estimating alignment properties with multiple samples \
+                                    in case you have only few reads."
+                                );
+                            }
                             let mut processor =
                                 calling::variants::preprocessing::ObservationProcessor::builder()
                                     .report_fragment_ids(report_fragment_ids)

--- a/src/variants/evidence/realignment/mod.rs
+++ b/src/variants/evidence/realignment/mod.rs
@@ -226,7 +226,6 @@ pub(crate) trait Realigner {
         let mut prob_ref_all = LogProb::ln_one();
         let mut prob_alt_all = LogProb::ln_one();
         let mut alt_edit_dist: Option<EditDistance> = None;
-        let mut is_third_allele = false;
 
         let ref_seq = self.ref_buffer().seq(record.contig())?;
         let read_seq: bam::record::Seq<'a> = record.seq();
@@ -284,7 +283,7 @@ pub(crate) trait Realigner {
             }
 
             // ref allele (or one of the alt variants)
-            let (mut prob_ref, _, _) = self.prob_allele(
+            let (mut prob_ref, ref_hit, _) = self.prob_allele(
                 &mut ref_emissions,
                 &mut edit_dist_calc,
                 alignment_properties,
@@ -342,7 +341,6 @@ pub(crate) trait Realigner {
                         self.calculate_prob_allele(&third_allele_hit, &mut read_inferred_allele);
                     if prob_read_inferred > prob_ref {
                         prob_ref = prob_read_inferred;
-                        is_third_allele = true;
                     }
                 }
             }
@@ -393,12 +391,21 @@ pub(crate) trait Realigner {
                 }
             }
 
-            if let Some(ref mut alt_edit_dist) = alt_edit_dist {
-                if let Some(ref hit_dist) = alt_hit.edit_distance() {
-                    alt_edit_dist.update(hit_dist);
-                }
+            // METHOD: Calculate relative edit dist of alt allele compared to ref allele.
+            // This is to normalize away edits that are in both alleles and only get what
+            // comes in addition in the alt allele.
+            let per_region_alt_edit_dist = if alt_hit.dist() >= ref_hit.dist() {
+                EditDistance((alt_hit.dist() - ref_hit.dist()) as u32)
             } else {
-                alt_edit_dist = alt_hit.edit_distance();
+                // METHOD: if the alt allele region has a better distance than the reference,
+                // there still might be edits within the actual alt allele change.
+                // We try to capture them here as a fallback.
+                alt_hit.edit_distance().unwrap_or(EditDistance(0))
+            };
+            if let Some(ref mut alt_edit_dist) = alt_edit_dist {
+                alt_edit_dist.update(&per_region_alt_edit_dist);
+            } else {
+                alt_edit_dist = Some(per_region_alt_edit_dist);
             }
 
             // METHOD: probabilities of independent regions are combined here.
@@ -417,7 +424,7 @@ pub(crate) trait Realigner {
             .homopolymer_indel_len(homopolymer_indel_len)
             .prob_ref_allele(prob_ref_all)
             .prob_alt_allele(prob_alt_all)
-            .third_allele_evidence(if is_third_allele { alt_edit_dist } else { None })
+            .third_allele_evidence(alt_edit_dist)
             .build()
             .unwrap())
     }

--- a/src/variants/evidence/realignment/mod.rs
+++ b/src/variants/evidence/realignment/mod.rs
@@ -391,16 +391,18 @@ pub(crate) trait Realigner {
                 }
             }
 
-            // METHOD: Calculate relative edit dist of alt allele compared to ref allele.
-            // This is to normalize away edits that are in both alleles and only get what
-            // comes in addition in the alt allele.
-            let per_region_alt_edit_dist = if alt_hit.dist() >= ref_hit.dist() {
+            let per_region_alt_edit_dist = if let Some(edit_dist) = alt_hit.edit_distance() {
+                // METHOD: edits within the actual alt allele change.
+                edit_dist
+            } else if alt_hit.dist() >= ref_hit.dist() {
+                // METHOD: Calculate relative edit dist of alt allele compared to ref allele.
+                // This is to normalize away edits that are in both alleles and only get what
+                // comes in addition in the alt allele.
+                // This is the fallback in case the alignment moves the edit outside of
+                // the alt allele locus.
                 EditDistance((alt_hit.dist() - ref_hit.dist()) as u32)
             } else {
-                // METHOD: if the alt allele region has a better distance than the reference,
-                // there still might be edits within the actual alt allele change.
-                // We try to capture them here as a fallback.
-                alt_hit.edit_distance().unwrap_or(EditDistance(0))
+                EditDistance(0)
             };
             if let Some(ref mut alt_edit_dist) = alt_edit_dist {
                 alt_edit_dist.update(&per_region_alt_edit_dist);

--- a/src/variants/evidence/realignment/pairhmm.rs
+++ b/src/variants/evidence/realignment/pairhmm.rs
@@ -416,7 +416,7 @@ impl<'a> bio::stats::pairhmm::Emission for ReadVsAlleleEmission<'a> {
     }
 }
 
-#[derive(Getters, CopyGetters)]
+#[derive(Getters, CopyGetters, Debug)]
 pub(crate) struct ReadEmission<'a> {
     #[getset(get = "pub(crate)")]
     pub(crate) read_seq: bam::record::Seq<'a>,


### PR DESCRIPTION


### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation warning when alignment feature probabilities exceed 0.3 in exact pairHMM mode.

* **Documentation**
  * Improved CLI help text for BAM input field clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->