### PR TITLE
fix: only output alt edit dist if the observation supports the ALT allele

### DIFF
--- a/src/variants/evidence/realignment/mod.rs
+++ b/src/variants/evidence/realignment/mod.rs
@@ -426,7 +426,7 @@ pub(crate) trait Realigner {
             .homopolymer_indel_len(homopolymer_indel_len)
             .prob_ref_allele(prob_ref_all)
             .prob_alt_allele(prob_alt_all)
-            .third_allele_evidence(if prob_alt_all > prob_ref_all { alt_edit_dist } else { None })
+            .third_allele_evidence(if prob_alt_all >= prob_ref_all { alt_edit_dist } else { None })
             .build()
             .unwrap())
     }

--- a/src/variants/evidence/realignment/mod.rs
+++ b/src/variants/evidence/realignment/mod.rs
@@ -426,7 +426,7 @@ pub(crate) trait Realigner {
             .homopolymer_indel_len(homopolymer_indel_len)
             .prob_ref_allele(prob_ref_all)
             .prob_alt_allele(prob_alt_all)
-            .third_allele_evidence(alt_edit_dist)
+            .third_allele_evidence(if prob_alt_all > prob_ref_all { alt_edit_dist } else { None })
             .build()
             .unwrap())
     }

--- a/src/variants/evidence/realignment/mod.rs
+++ b/src/variants/evidence/realignment/mod.rs
@@ -426,7 +426,11 @@ pub(crate) trait Realigner {
             .homopolymer_indel_len(homopolymer_indel_len)
             .prob_ref_allele(prob_ref_all)
             .prob_alt_allele(prob_alt_all)
-            .third_allele_evidence(if prob_alt_all >= prob_ref_all { alt_edit_dist } else { None })
+            .third_allele_evidence(if prob_alt_all >= prob_ref_all {
+                alt_edit_dist
+            } else {
+                None
+            })
             .build()
             .unwrap())
     }


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of third-allele evidence so it’s only included when overall allele probabilities support it. This reduces spurious third-allele reports, leads to more consistent evidence emission, and improves the accuracy and reliability of variant calling output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->