### PR TITLE
fix: ensure that dummy third alleles also work in repetitive regions; stop estimating artifact gap extensions via looking at true extensions in the data, instead estimate them from gap openings, which is more robust since we have more data for that

### DIFF
--- a/src/calling/variants/calling.rs
+++ b/src/calling/variants/calling.rs
@@ -30,7 +30,7 @@ use crate::calling::variants::{
 use crate::errors;
 use crate::grammar;
 use crate::utils::aux_info::AuxInfoCollector;
-use crate::utils::{self, interpolate_prob, PathMap};
+use crate::utils::{self, PathMap};
 use crate::variants::evidence::observations::pileup::Pileup;
 
 use crate::variants::model::modes::generic::LikelihoodOperands;

--- a/src/estimation/alignment_properties.rs
+++ b/src/estimation/alignment_properties.rs
@@ -865,7 +865,7 @@ impl AlignmentProperties {
         if let Some(transition_counts) = &self.transition_counts {
             let mut insufficient_counts = false;
             use State::*;
-            let [[prob_insertion_artifact, prob_insertion_extend_artifact], [prob_deletion_artifact, prob_deletion_extend_artifact]] =
+            let [[prob_insertion_artifact, _prob_insertion_extend_artifact], [prob_deletion_artifact, _prob_deletion_extend_artifact]] =
                 [GapX, GapY].map(|gap| {
                     // Number of transitions from match states to gap state
                     let from_match_to_gap = [MatchA, MatchC, MatchG, MatchT]
@@ -906,11 +906,20 @@ impl AlignmentProperties {
                     "Insufficient observations for hop parameter estimation"
                 ));
             }
+
+            // METHOD: estimating true gap extends is risky, as there might be predominantly true indels
+            // that are longer than 1. We have seen samples where this would cause gap extension
+            // probabilities close to 1.0, which causes all kinds of false positive indel calls.
+            // Instead, we consider gap extensions as likely as gap openings.
+            // This assumes that the artifact indel probability is actually constant and does not change
+            // depending on how large the artifact already is.
+            // This also reflects our findings on homopolymer indels, where this could be shown as well.
+
             Ok(GapParams {
                 prob_insertion_artifact,
                 prob_deletion_artifact,
-                prob_insertion_extend_artifact,
-                prob_deletion_extend_artifact,
+                prob_insertion_extend_artifact: prob_insertion_artifact,
+                prob_deletion_extend_artifact: prob_deletion_artifact,
             })
         } else {
             warn!("Insufficient observations for hop parameter estimation, falling back to default hop parameters");

--- a/src/variants/evidence/realignment/edit_distance.rs
+++ b/src/variants/evidence/realignment/edit_distance.rs
@@ -386,76 +386,16 @@ impl EditDistanceCalculation {
 
             let alignment = edit_distance_hit.some_alignment();
 
-            // relative position in the emission snippet we have aligned against
-            let mut pos_ref = alignment.start;
-            let mut pos_read = 0; // semiglobal alignment
-
             let mut allele = Vec::new();
             // add part before the alignment
             allele.extend((0..alignment.start).map(|i| emission_params.ref_base(i)));
-
-            for op in alignment.operations() {
-                let is_in_range = emission_params
-                    .is_in_variant_ref_range(pos_ref as u64 + emission_params.ref_offset() as u64);
-                match op {
-                    AlignmentOperation::Match => {
-                        allele.push(emission_params.ref_base(pos_ref));
-                        pos_ref += 1;
-                        pos_read += 1;
-                    }
-                    AlignmentOperation::Subst => {
-                        allele.push(if is_in_range {
-                            self.read_seq[pos_read]
-                        } else {
-                            emission_params.ref_base(pos_ref)
-                        });
-                        pos_ref += 1;
-                        pos_read += 1;
-                    }
-                    AlignmentOperation::Del => {
-                        if is_in_range {
-                            pos_ref += 1;
-                        } else {
-                            emission_params.ref_base(pos_ref);
-                            pos_ref += 1;
-                        }
-                    }
-                    AlignmentOperation::Ins => {
-                        if is_in_range {
-                            allele.push(self.read_seq[pos_read]);
-                            pos_read += 1;
-                        } else {
-                            pos_read += 1;
-                        }
-                    }
-                    _ => {
-                        unreachable!("bug: unexpected alignment operation")
-                    }
-                }
-            }
-
-            let del_len = cmp::min(emission_params.alt_vs_ref_len_diff(), 0).unsigned_abs();
-            // add the remaining sequence
-            // be robust to del_len being too large (can happen when the encoding in the VCF is wrong)
-            allele.extend(
-                (pos_ref
-                    ..cmp::max(
-                        (emission_params.ref_end() - emission_params.ref_offset())
-                            .saturating_sub(del_len),
-                        pos_ref,
-                    ))
-                    //(pos_ref..emission_params.ref_end() - emission_params.ref_offset())
-                    .map(|i| emission_params.ref_base(i)),
-            );
-
-            // Adjust ref_end by end_reduce, in order to ensure that deletions in var_range do not shorten the allele
-            // without adjusting the ref_end.
+            allele.extend(self.read_seq.iter());
 
             Some(ReadVsAlleleEmission::new(
                 emission_params.read_emission(),
                 Box::new(PatchedAlleleEmission {
                     ref_offset: emission_params.allele_emission().ref_offset(),
-                    ref_end: emission_params.allele_emission().ref_offset() + allele.len(), //emission_params.allele_emission().ref_end(),
+                    ref_end: emission_params.allele_emission().ref_offset() + allele.len(),
                     patched_seq: allele,
                     ref_offset_override: None,
                     ref_end_override: None,
@@ -542,10 +482,6 @@ impl RefBaseEmission for PatchedAlleleEmission {
 
 impl VariantEmission for PatchedAlleleEmission {
     fn is_homopolymer_indel(&self) -> bool {
-        unreachable!("bug: PatchedAlleleEmission should not be used as a normal alt allele");
-    }
-
-    fn alt_vs_ref_len_diff(&self) -> isize {
         unreachable!("bug: PatchedAlleleEmission should not be used as a normal alt allele");
     }
 }

--- a/src/variants/evidence/realignment/mod.rs
+++ b/src/variants/evidence/realignment/mod.rs
@@ -235,6 +235,8 @@ pub(crate) trait Realigner {
         let mut strand = Strand::None;
         let mut homopolymer_indel_len = None;
 
+        let mut is_third_allele_evidence = false;
+
         for region in merged_regions {
             // read emission
             let read_emission = ReadEmission::new(
@@ -341,6 +343,7 @@ pub(crate) trait Realigner {
                         self.calculate_prob_allele(&third_allele_hit, &mut read_inferred_allele);
                     if prob_read_inferred > prob_ref {
                         prob_ref = prob_read_inferred;
+                        is_third_allele_evidence = true;
                     }
                 }
             }
@@ -426,11 +429,13 @@ pub(crate) trait Realigner {
             .homopolymer_indel_len(homopolymer_indel_len)
             .prob_ref_allele(prob_ref_all)
             .prob_alt_allele(prob_alt_all)
-            .third_allele_evidence(if prob_alt_all >= prob_ref_all {
-                alt_edit_dist
-            } else {
-                None
-            })
+            .third_allele_evidence(
+                if prob_alt_all >= prob_ref_all || is_third_allele_evidence {
+                    alt_edit_dist
+                } else {
+                    None
+                },
+            )
             .build()
             .unwrap())
     }

--- a/src/variants/evidence/realignment/pairhmm.rs
+++ b/src/variants/evidence/realignment/pairhmm.rs
@@ -76,8 +76,6 @@ pub(crate) trait RefBaseEmission {
 
 pub(crate) trait VariantEmission {
     fn is_homopolymer_indel(&self) -> bool;
-
-    fn alt_vs_ref_len_diff(&self) -> isize;
 }
 
 #[macro_export]
@@ -368,10 +366,6 @@ impl<'a> VariantEmission for ReadVsAlleleEmission<'a> {
     fn is_homopolymer_indel(&self) -> bool {
         self.allele_emission.is_homopolymer_indel()
     }
-
-    fn alt_vs_ref_len_diff(&self) -> isize {
-        self.allele_emission.alt_vs_ref_len_diff()
-    }
 }
 
 impl<'a> pairhmm::EmissionParameters for ReadVsAlleleEmission<'a> {
@@ -519,10 +513,6 @@ impl RefBaseEmission for ReferenceEmissionParams {
 impl VariantEmission for ReferenceEmissionParams {
     fn is_homopolymer_indel(&self) -> bool {
         false
-    }
-
-    fn alt_vs_ref_len_diff(&self) -> isize {
-        0
     }
 }
 

--- a/src/variants/types/breakends.rs
+++ b/src/variants/types/breakends.rs
@@ -900,10 +900,6 @@ impl VariantEmission for BreakendEmissionParams {
     fn is_homopolymer_indel(&self) -> bool {
         false
     }
-
-    fn alt_vs_ref_len_diff(&self) -> isize {
-        0 // since the whole alt_allele sequence is replaced, this has no relevance
-    }
 }
 
 /// Modeling of breakends.

--- a/src/variants/types/deletion.rs
+++ b/src/variants/types/deletion.rs
@@ -342,8 +342,4 @@ impl VariantEmission for DeletionEmissionParams {
     fn is_homopolymer_indel(&self) -> bool {
         self.homopolymer.is_some()
     }
-
-    fn alt_vs_ref_len_diff(&self) -> isize {
-        -(self.del_len as isize)
-    }
 }

--- a/src/variants/types/insertion.rs
+++ b/src/variants/types/insertion.rs
@@ -280,8 +280,4 @@ impl VariantEmission for InsertionEmissionParams {
     fn is_homopolymer_indel(&self) -> bool {
         self.homopolymer.is_some()
     }
-
-    fn alt_vs_ref_len_diff(&self) -> isize {
-        self.ins_len as isize
-    }
 }

--- a/src/variants/types/mnv.rs
+++ b/src/variants/types/mnv.rs
@@ -352,8 +352,4 @@ impl VariantEmission for MnvEmissionParams {
     fn is_homopolymer_indel(&self) -> bool {
         false
     }
-
-    fn alt_vs_ref_len_diff(&self) -> isize {
-        0
-    }
 }

--- a/src/variants/types/replacement.rs
+++ b/src/variants/types/replacement.rs
@@ -313,8 +313,4 @@ impl VariantEmission for ReplacementEmissionParams {
     fn is_homopolymer_indel(&self) -> bool {
         self.is_homopolymer_indel
     }
-
-    fn alt_vs_ref_len_diff(&self) -> isize {
-        self.repl_alt_len as isize - self.repl_ref_len as isize
-    }
 }

--- a/src/variants/types/snv.rs
+++ b/src/variants/types/snv.rs
@@ -295,10 +295,6 @@ impl VariantEmission for SnvEmissionParams {
     fn is_homopolymer_indel(&self) -> bool {
         false
     }
-
-    fn alt_vs_ref_len_diff(&self) -> isize {
-        0
-    }
 }
 
 // #[cfg(test)]

--- a/tests/resources/testcases/test_giab_12/testcase.yaml
+++ b/tests/resources/testcases/test_giab_12/testcase.yaml
@@ -1,8 +1,11 @@
-# True GIAB variant (1:1900106).
+# True GIAB variant (1:1900106), but the data clearly shows that the variant is wrong!!
+# It should be T>TCTC, not T>TCCT. Varlociraptor detects that correctly by observing that the edit distance
+# against the candidate insertion is too high and aligns the reads against a dummy
+# third allele derived from the read itself, leading to a VAF of 0 for T>TCCT.
 
 expected:
   allelefreqs:
-    - index == 0.5
+    - index == 0.0
 
 # necessary bam files
 samples:
@@ -10,7 +13,7 @@ samples:
     path: 'index.bam'
     properties: '{"insert_size":{"mean":258.30594965675056,"sd":78.43317321489799},"max_del_cigar_len":18,"max_ins_cigar_len":12,"frac_max_softclip":0.8118811881188119,"max_read_len":101,"initial":false}'
     options: '{"Preprocess":{"kind":{"Variants":{"reference":"?","candidates":"?","bam":"?","reference_buffer_size":10,"min_bam_refetch_distance":1,"alignment_properties":null,"output":"?","spurious_ins_rate":2.8e-6,"spurious_del_rate":5.1e-6,"spurious_insext_rate":0.0,"spurious_delext_rate":0.0,"protocol_strandedness":"Opposite","realignment_window":64,"max_depth":200,"omit_insert_size":false,"pairhmm_mode":"exact"}}}}'
-  
+
 
 # candidate variant
 candidate: 'candidates.vcf'


### PR DESCRIPTION

### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gap extension probability modeling during alignment analysis
  * Enhanced third allele evidence detection in variant calling
  * Corrected allele frequency calculations for problematic variants

* **Refactor**
  * Simplified internal allele construction logic
  * Removed unused variant emission interface methods

* **Tests**
  * Updated test expectations for GIAB variant handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->