### PR TITLE
fix: correct borders for vaf splitting

### DIFF
--- a/src/grammar/formula.rs
+++ b/src/grammar/formula.rs
@@ -1110,18 +1110,18 @@ impl VAFRange {
         );
         let left = VAFRange {
             inner: self.start..vaf,
-            left_exclusive: self.left_exclusive,
+            left_exclusive: self.left_exclusive || self.start == vaf,
             right_exclusive: true,
         };
         let right = VAFRange {
             inner: vaf..self.end,
             left_exclusive: true,
-            right_exclusive: self.right_exclusive,
+            right_exclusive: self.right_exclusive || self.end == vaf,
         };
 
         let to_spectrum = |range: VAFRange| {
             if range.start == range.end {
-                if !(range.left_exclusive && self.right_exclusive) {
+                if !(range.left_exclusive && range.right_exclusive) {
                     Some(VAFSpectrum::singleton(range.start))
                 } else {
                     None


### PR DESCRIPTION
### Description

This PR fixes the splitting logic for VAFRanges.

Previously, when an interval was split at a specific VAF value, the interval boundaries were not computed correctly if the split position is exactly equal to one of the existing borders.

The fix ensures that boundary conditions are handled properly when the split point lies exactly on an interval border.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced range boundary handling during split operations to correctly propagate exclusivity when splitting at specific boundary values. Updated singleton condition determination to be properly based on the actual updated range boundaries instead of the original range boundaries, thereby improving the overall accuracy of range calculations, especially in complex boundary scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->