### PR TITLE
perf: avoid logging every non-coding variant when estimating mutational burden

### DIFF
--- a/src/estimation/mutational_burden.rs
+++ b/src/estimation/mutational_burden.rs
@@ -127,10 +127,6 @@ pub(crate) fn collect_estimates(
             vafmap.insert(name, vafs);
         }
         if !is_valid_variant(&mut rec, &header)? {
-            info!(
-                "Skipping variant {}:{} because it is not coding.",
-                contig, vcfpos
-            );
             continue;
         }
 


### PR DESCRIPTION


### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No user-facing changes in this release. This update contains internal optimizations with no impact on application functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->