### PR TITLE
perf: early stop in recursive model evaluation in case a sample is is requested to have VAF <1.0 but all observations clearly support the alt allele

### DIFF
--- a/src/variants/evidence/observations/read_observation.rs
+++ b/src/variants/evidence/observations/read_observation.rs
@@ -445,6 +445,11 @@ impl<P: Clone, A: Clone> ReadObservation<P, A> {
             >= KassRaftery::Positive
     }
 
+    pub fn is_positive_alt_support(&self) -> bool {
+        BayesFactor::new(self.prob_alt, self.prob_ref).evidence_kass_raftery()
+            >= KassRaftery::Positive
+    }
+
     pub fn has_homopolymer_error(&self) -> bool {
         self.homopolymer_indel_len
             .map(|indel_len| indel_len != 0)

--- a/src/variants/model/modes/generic.rs
+++ b/src/variants/model/modes/generic.rs
@@ -267,7 +267,7 @@ impl GenericPosterior {
                     }
                 }
 
-                let (n_obs, is_clear_ref) = {
+                let (n_obs, is_clear_ref, is_clear_hom_alt) = {
                     let pileup = &data.pileups[*sample];
                     if pileup.read_observations().is_empty()
                         && !pileup.depth_observations().is_empty()
@@ -277,7 +277,7 @@ impl GenericPosterior {
                         // Hence we always assume that there is no clear ref support and do the full
                         // evaluation below.
                         // This should be fine since there should be much less CNV calls than small variants.
-                        (pileup.depth_observations().len(), false)
+                        (pileup.depth_observations().len(), false, false)
                     } else {
                         // normal variants, only consider read observations for these heuristic markers
                         let n_obs = pileup.read_observations().len();
@@ -286,7 +286,12 @@ impl GenericPosterior {
                                 .read_observations()
                                 .iter()
                                 .all(|obs| obs.is_positive_ref_support());
-                        (n_obs, is_clear_ref)
+                        let is_clear_hom_alt = n_obs > 10
+                            && pileup
+                                .read_observations()
+                                .iter()
+                                .all(|obs| obs.is_positive_alt_support());
+                        (n_obs, is_clear_ref, is_clear_hom_alt)
                     }
                 };
 
@@ -298,6 +303,13 @@ impl GenericPosterior {
                             // immediately stop, returning a probability of zero.
                             return LogProb::ln_zero();
                         }
+                        if is_clear_hom_alt && vafs.iter().all(|vaf| **vaf < 1.0) {
+                            // METHOD: shortcut for the case that all obs support the alt but the vafs
+                            // in this event are < 1. Then, we don't need to recurse further and can
+                            // immediately stop, returning a probability of zero.
+                            return LogProb::ln_zero();
+                        }
+
                         let vafs = if let Some(lfc_bounds) = &lfc_bounds {
                             vafs.iter()
                                 .filter(|vaf| lfc_bounds.contains(**vaf))


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added method to assess whether evidence supports the alternate allele above a positive significance threshold.

* **Performance**
  * Optimized density calculations with early-exit logic for clear homozygous alternate cases, reducing unnecessary computation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->