### PR TITLE
feat: add tooltips to mutational burden plots

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -29,7 +29,7 @@ pub(crate) enum Error {
         pos: i64,
         msg: String,
     },
-    #[error("unable to estimate TMB because no valid records were found in the given BCF/VCF")]
+    #[error("unable to estimate mutational burden because no valid records were found in the given BCF/VCF")]
     NoRecordsFound,
     #[error("contig {contig} not found in universe definition and no 'all' defined")]
     UniverseContigNotFound { contig: String },

--- a/src/estimation/mutational_burden.rs
+++ b/src/estimation/mutational_burden.rs
@@ -126,9 +126,10 @@ pub(crate) fn collect_estimates(
             let vafs = rec.format(b"AF").float()?[*id].to_owned();
             vafmap.insert(name, vafs);
         }
-        if !is_valid_variant(&mut rec, &header)? {
-            continue;
-        }
+        // if !is_valid_variant(&mut rec, &header)? {
+        //     continue;
+        // }
+        // info!("valid variant at {}:{}", contig, vcfpos);
 
         let alt_allele_count = (rec.allele_count() - 1) as usize;
 
@@ -490,7 +491,7 @@ pub(crate) fn signatures(record: &bcf::Record) -> Vec<Signature> {
                 Signature::Bnd
             } else if alt_allele == b"<METH>" {
                 Signature::Meth
-            } else if ref_allele.len() == 1 && alt_allele.len() == 1 {
+            } else if ref_allele.len() == 1 && alt_allele.len() == 1 && b"ACGT".contains(&ref_allele[0]) && b"ACGT".contains(&alt_allele[0]) {
                 Signature::from_str(&format!(
                     "{}>{}",
                     str::from_utf8(ref_allele).unwrap(),

--- a/templates/plots/vaf_curve.json
+++ b/templates/plots/vaf_curve.json
@@ -8,7 +8,11 @@
       "height": 87,
       "encoding": {
         "x": {"field": "min_vaf", "type": "quantitative", "axis": { "title": "", "labels": false, "ticks": false }},
-        "y": {"field": "tmb", "type": "quantitative", "axis": { "title": "" }, "scale": {"domain": [200, 420], "nice": false}}
+        "y": {"field": "tmb", "type": "quantitative", "axis": { "title": "" }, "scale": {"domain": [200, 420], "nice": false}},
+        "tooltip": [
+          {"field": "min_vaf", "type": "quantitative", "title": "minimum VAF"},
+          {"field": "tmb", "type": "quantitative", "title": "mutations/Mb", "format": ".3f"}
+        ]
       }
     },
     {
@@ -16,7 +20,11 @@
       "height": 143,
       "encoding": {
         "x": {"field": "min_vaf", "type": "quantitative", "axis": { "title": "minimum VAF" }},
-        "y": {"field": "tmb", "type": "quantitative", "axis": { "title": "mutations/Mb" }, "scale": {"domain": [0, 199.9], "nice": false}}
+        "y": {"field": "tmb", "type": "quantitative", "axis": { "title": "mutations/Mb" }, "scale": {"domain": [0, 199.9], "nice": false}},
+        "tooltip": [
+          {"field": "min_vaf", "type": "quantitative", "title": "minimum VAF"},
+          {"field": "tmb", "type": "quantitative", "title": "mutations/Mb", "format": ".3f"}
+        ]
       }
     }
   ],

--- a/templates/plots/vaf_curve_strat.json
+++ b/templates/plots/vaf_curve_strat.json
@@ -2,6 +2,18 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
     "description": "Mutational burden.",
     "data": { "values": [] },
+    "transform": [
+      {
+        "joinaggregate": [
+          {
+            "op": "sum",
+            "field": "mb",
+            "as": "total_mb"
+          }
+        ],
+        "groupby": ["min_vaf"]
+      }
+    ],
     "vconcat": [
       {
         "mark": { "type": "area", "clip": true },
@@ -9,7 +21,13 @@
         "encoding": {
           "x": {"field": "min_vaf", "type": "quantitative", "axis": { "title": "", "labels": false, "ticks": false }},
           "y": {"field": "mb", "type": "quantitative", "axis": { "title": "" }, "stack": true, "scale": {"domain": [200, 420], "nice": false}},
-          "color": {"field": "vartype", "type": "nominal", "scale": { "scheme": "tableau20"}}
+          "color": {"field": "vartype", "type": "nominal", "scale": { "scheme": "tableau20"}},
+          "tooltip": [
+            {"field": "min_vaf", "type": "quantitative", "title": "minimum VAF"},
+            {"field": "total_mb", "type": "quantitative", "title": "total mutations/Mb", "format": ".3f"},
+            {"field": "vartype", "type": "nominal", "title": "variant type"},
+            {"field": "mb", "type": "quantitative", "title": "type specific mutations/Mb", "format": ".3f"}
+          ]
         }
       },
       {
@@ -18,7 +36,13 @@
         "encoding": {
           "x": {"field": "min_vaf", "type": "quantitative", "axis": { "title": "minimum VAF" }},
           "y": {"field": "mb", "type": "quantitative", "axis": { "title": "mutations/Mb" }, "stack": true, "scale": {"domain": [0, 199.9], "nice": false}},
-          "color": {"field": "vartype", "type": "nominal", "scale": { "scheme": "tableau20"}}
+          "color": {"field": "vartype", "type": "nominal", "scale": { "scheme": "tableau20"}},
+          "tooltip": [
+            {"field": "min_vaf", "type": "quantitative", "title": "minimum VAF"},
+            {"field": "total_mb", "type": "quantitative", "title": "total mutations/Mb", "format": ".3f"},
+            {"field": "vartype", "type": "nominal", "title": "variant type"},
+            {"field": "mb", "type": "quantitative", "title": "type specific mutations/Mb", "format": ".3f"}
+          ]
         }
       }
     ],


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation at https://github.com/varlociraptor/varlociraptor.github.io is updated in a separate PR to reflect the changes or this is not necessary (e.g. if the change does neither modify the calling grammar nor the behavior or functionalities of Varlociraptor).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * VAF curve visualizations now show richer, formatted hover tooltips for minimum VAF and mutation burden metrics.
  * Stratified VAF curves now include aggregated mutation burden totals and expanded tooltip details (including per-variant-type values).

* **Bug Fixes**
  * Mutational burden estimation was adjusted to consider a broader set of records, improving coverage.
  * SNV signature classification was tightened to only treat standard A/C/G/T substitutions as single-base matches.
  * Updated the “no records found” error message to reflect mutational burden estimation more accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->