### PR TITLE
feat(grammar): verify pairwise event disjointness at scenario compilation

### DIFF
--- a/src/grammar/formula.rs
+++ b/src/grammar/formula.rs
@@ -1052,6 +1052,47 @@ impl VAFSpectrum {
             VAFSpectrum::Range(range) => range.is_complete(),
         }
     }
+
+    /// Intersection of two spectra. Returns an empty spectrum if they are disjoint.
+    pub(crate) fn intersect(&self, other: &VAFSpectrum) -> VAFSpectrum {
+        match (self, other) {
+            (VAFSpectrum::Range(a), VAFSpectrum::Range(b)) => {
+                let r = a.intersect(b);
+                if r.is_empty() {
+                    VAFSpectrum::empty()
+                } else if r.is_singleton() {
+                    VAFSpectrum::singleton(r.start)
+                } else {
+                    VAFSpectrum::Range(r)
+                }
+            }
+            (VAFSpectrum::Range(r), VAFSpectrum::Set(s))
+            | (VAFSpectrum::Set(s), VAFSpectrum::Range(r)) => {
+                VAFSpectrum::Set(s.iter().filter(|v| r.contains(**v)).cloned().collect())
+            }
+            (VAFSpectrum::Set(a), VAFSpectrum::Set(b)) => {
+                VAFSpectrum::Set(a.intersection(b).cloned().collect())
+            }
+        }
+    }
+
+    /// Pick a representative allele frequency that is contained in this spectrum, or `None` if the
+    /// spectrum is empty. For ranges, the midpoint is returned, which is strictly interior and thus
+    /// contained regardless of the range's exclusivity.
+    pub(crate) fn representative(&self) -> Option<AlleleFreq> {
+        match self {
+            VAFSpectrum::Set(s) => s.iter().next().copied(),
+            VAFSpectrum::Range(r) => {
+                if r.is_empty() {
+                    None
+                } else if r.is_singleton() {
+                    Some(r.start)
+                } else {
+                    Some(AlleleFreq((*r.start + *r.end) / 2.0))
+                }
+            }
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, TypedBuilder, Hash, CopyGetters)]

--- a/src/grammar/mod.rs
+++ b/src/grammar/mod.rs
@@ -14,7 +14,6 @@ pub(crate) mod formula;
 pub(crate) mod vaftree;
 
 use crate::errors;
-use crate::grammar::formula::FormulaTerminal;
 pub(crate) use crate::grammar::formula::{Formula, VAFRange, VAFSpectrum, VAFUniverse};
 pub(crate) use crate::grammar::vaftree::VAFTree;
 use crate::variants::model::{AlleleFreq, VariantType};
@@ -205,75 +204,67 @@ impl Scenario {
 
     pub(crate) fn vaftrees(&self, contig: &str) -> Result<HashMap<String, VAFTree>> {
         info!("Preprocessing events for contig {}", contig);
-        let trees = self
-            .events()
-            .iter()
-            .map(|(name, formula)| {
-                let normalized = formula
-                    .normalize(self, contig)
-                    .with_context(|| format!("invalid event definition for {}", name))?;
-                info!("    {}: {}", name, normalized);
-                let vaftree = VAFTree::new(&normalized, self, contig)?;
-                Ok((name.to_owned(), vaftree))
-            })
-            .collect();
-        self.validate(contig)?;
-        trees
+        let mut trees = HashMap::new();
+        for (name, formula) in self.events() {
+            let normalized = formula
+                .normalize(self, contig)
+                .with_context(|| format!("invalid event definition for {}", name))?;
+            info!("    {}: {}", name, normalized);
+            let vaftree = VAFTree::new(&normalized, self, contig)?;
+            trees.insert(name.to_owned(), vaftree);
+        }
+        self.validate(&trees, contig)?;
+        Ok(trees)
     }
 
-    pub(crate) fn validate(&self, contig: &str) -> Result<()> {
-        let names = self
-            .events()
+    /// Verify the invariant that all events are pairwise disjoint: there must be no combination of
+    /// allele frequencies (within the declared universes) for which more than one event is true.
+    /// The generic model treats events as mutually exclusive when summing posterior probabilities,
+    /// so a violation silently distorts the results. On violation, the returned error names every
+    /// offending pair and exhibits a concrete witness assignment.
+    ///
+    /// Disjointness is checked per contig, because a sample's universe (and hence the events) may
+    /// depend on the contig via ploidy or contig-specific universe definitions.
+    fn validate(&self, trees: &HashMap<String, VAFTree>, contig: &str) -> Result<()> {
+        // Resolve each sample's universe once, indexed by the sample index used inside the trees
+        // (the enumeration order of `samples()`, which drives `Scenario::idx`).
+        let universes: Vec<(String, VAFUniverse)> = self
+            .samples()
             .iter()
-            .filter(|(name, _)| *name != "absent")
-            .map(|(name, formula)| {
-                (
-                    // if `formula.normalize(…)` failed above, we won't get to this line,
-                    // so we might as well unwrap.
-                    formula.normalize(self, contig).map(Formula::from).unwrap(),
-                    name,
-                )
+            .map(|(name, sample)| {
+                Ok((
+                    name.clone(),
+                    sample.contig_universe(contig, self.species())?,
+                ))
             })
-            .into_group_map();
-        let mut overlapping = vec![];
-        let events: Vec<_> = names.keys().sorted().cloned().collect();
-        for (e1, e2) in events.iter().tuple_combinations() {
-            // skip comparison of event with itself
-            if e1 == e2 {
-                continue;
-            }
-            let terms = [e1, e2]
-                .iter()
-                .filter(|e| !matches!(e.to_terminal(), Some(FormulaTerminal::False)))
-                .map(|&v| v.clone())
-                .collect_vec();
+            .collect::<Result<_>>()?;
 
-            // skip if any of the operands is a terminal `False`.
-            if terms.len() != 2 {
-                continue;
-            }
+        // The auto-generated `absent` event is excluded, matching the previous behaviour.
+        let names: Vec<&String> = trees
+            .keys()
+            .filter(|name| *name != "absent")
+            .sorted()
+            .collect();
 
-            // TODO make sure the disjunction really is canonical, such that trying to check if it's contained in `events` isn't a game of chance
-            let disjunction =
-                Formula::from(Formula::Disjunction { operands: terms }.normalize(self, contig)?);
-            if events.contains(&disjunction) {
-                overlapping.push((
-                    names[e1].clone(),
-                    names[e2].clone(),
-                    names[&disjunction].clone(),
-                ));
+        let mut overlapping = Vec::new();
+        for (i, name_a) in names.iter().enumerate() {
+            for name_b in &names[i + 1..] {
+                if let Some(witness) = trees[*name_a].overlap_witness(&trees[*name_b], &universes) {
+                    overlapping.push(format!(
+                        "{:?} and {:?} (witness: {})",
+                        name_a, name_b, witness
+                    ));
+                }
             }
         }
-        if !overlapping.is_empty() {
-            return Err(crate::errors::Error::OverlappingEvents {
-                expressions: overlapping
-                    .iter()
-                    .map(|(a1, a2, f)| format!("({:?} | {:?}) = {:?}", a1, a2, f))
-                    .join(", "),
-            }
-            .into());
-        } else {
+
+        if overlapping.is_empty() {
             Ok(())
+        } else {
+            Err(crate::errors::Error::OverlappingEvents {
+                expressions: overlapping.join("; "),
+            }
+            .into())
         }
     }
 }
@@ -651,4 +642,168 @@ pub(crate) enum Sex {
 pub(crate) enum UniverseDefinition {
     Map(BTreeMap<String, VAFUniverse>),
     Simple(VAFUniverse),
+}
+
+#[cfg(test)]
+mod validate_tests {
+    use super::Scenario;
+
+    fn scenario(yaml: &str) -> Scenario {
+        serde_yaml::from_str(yaml).unwrap()
+    }
+
+    /// Compile the events for contig `all` and return the disjointness error message, or `None` if
+    /// the scenario validated successfully.
+    fn overlap_error(yaml: &str) -> Option<String> {
+        match scenario(yaml).vaftrees("all") {
+            Ok(_) => None,
+            Err(err) => Some(format!("{}", err)),
+        }
+    }
+
+    #[test]
+    fn documented_counter_example_is_rejected() {
+        // From the documentation: a `somatic_normal` defined as normal:]0.0,0.5] overlaps
+        // `germline` on normal:0.5.
+        let msg = overlap_error(
+            r#"
+samples:
+  normal:
+    resolution: 0.1
+    universe: "0.0 | 0.5 | 1.0 | ]0.0,0.5["
+events:
+  germline: "normal:0.5"
+  somatic_normal: "normal:]0.0,0.5]""#,
+        )
+        .expect("expected overlapping events to be rejected");
+        assert!(msg.contains("germline"), "message: {}", msg);
+        assert!(msg.contains("somatic_normal"), "message: {}", msg);
+        // The witness must exhibit the offending allele frequency.
+        assert!(msg.contains("normal=0.5"), "message: {}", msg);
+    }
+
+    #[test]
+    fn disjoint_tumor_normal_scenario_validates() {
+        assert_eq!(
+            overlap_error(
+                r#"
+species:
+  heterozygosity: 0.001
+  ploidy: 2
+samples:
+  tumor:
+    somatic-effective-mutation-rate: 1e-6
+    inheritance:
+      clonal:
+        from: normal
+        somatic: false
+  normal:
+    sex: female
+events:
+  somatic_tumor: "normal:0.0 & tumor:]0.0,1.0]"
+  germline: "normal:0.5 | normal:1.0""#,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn identical_events_overlap() {
+        let msg = overlap_error(
+            r#"
+samples:
+  normal:
+    universe: "0.0 | 0.5 | 1.0"
+events:
+  a: "normal:0.5"
+  b: "normal:0.5""#,
+        )
+        .expect("two identical events must be reported as overlapping");
+        assert!(msg.contains("normal=0.5"), "message: {}", msg);
+    }
+
+    #[test]
+    fn overlapping_ranges_yield_interior_witness() {
+        let msg = overlap_error(
+            r#"
+samples:
+  normal:
+    resolution: 0.01
+    universe: "[0.0,1.0]"
+events:
+  part1: "normal:[0.0,0.7]"
+  part2: "normal:[0.3,1.0]""#,
+        )
+        .expect("overlapping ranges must be rejected");
+        // Witness is the midpoint of [0.3, 0.7].
+        assert!(msg.contains("normal=0.5"), "message: {}", msg);
+    }
+
+    #[test]
+    fn full_overlapping_scenario_is_rejected() {
+        // The canonical `test_overlapping_events` fixture: riddled with overlaps.
+        assert!(overlap_error(
+            r#"
+samples:
+  tumor:
+    contamination:
+      by: normal
+      fraction: 0.25
+    resolution: 0.01
+    universe: "[0.0,1.0]"
+  normal:
+    resolution: 0.1
+    universe: "[0.0,0.5[ | 0.5 | 1.0"
+events:
+  somatic: "tumor:]0.0,1.0] & normal:[0.0,0.5["
+  somatic_tumor:  "tumor:]0.0,1.0] & normal:0.0"
+  somatic_normal: "tumor:]0.0,1.0] & normal:]0.0,0.5["
+  germline: "normal:0.5 | normal:1.0"
+  germline_het:   "tumor:[0.0,1.0] & normal:0.5"
+  germline_hom:   "tumor:[0.0,1.0] & normal:1.0""#,
+        )
+        .is_some());
+    }
+
+    #[test]
+    fn events_distinguished_only_by_log2fold_change_are_disjoint() {
+        // `a_greater_b` and `b_greater_a` overlap at l2fc == 1.0, but the model treats
+        // differing log2-fold-change predicates as disjoint (exact fact-set consumption), so the
+        // scenario must validate.
+        assert_eq!(
+            overlap_error(
+                r#"
+samples:
+  sample_a:
+    resolution: 0.01
+    universe: "[0.0,1.0]"
+  sample_b:
+    resolution: 0.01
+    universe: "[0.0,1.0]"
+events:
+  similar: "l2fc(sample_a,sample_b) < 1.0 & l2fc(sample_b,sample_a) < 1.0"
+  a_greater_b: "l2fc(sample_a,sample_b) >= 1.0"
+  b_greater_a: "l2fc(sample_a,sample_b) <= 1.0""#,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn events_distinguished_only_by_variant_are_disjoint() {
+        // Same VAF range, complementary variant constraints: disjoint via the variant terminal.
+        assert_eq!(
+            overlap_error(
+                r#"
+samples:
+  tumor:
+    resolution: 0.01
+    universe: "[0.0,1.0]"
+events:
+  ffpe_artifact: "(C>T | G>A) & tumor:]0.0,0.05["
+  present: "!(C>T | G>A) & tumor:]0.0,0.05[""#,
+            ),
+            None
+        );
+    }
 }

--- a/src/grammar/vaftree.rs
+++ b/src/grammar/vaftree.rs
@@ -1,10 +1,13 @@
-use std::collections::HashSet;
+use std::collections::btree_map::Entry;
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use anyhow::Result;
 use itertools::Itertools;
 
 use crate::errors;
-use crate::grammar::{formula::Iupac, formula::NormalizedFormula, Scenario, VAFSpectrum};
+use crate::grammar::{
+    formula::Iupac, formula::NormalizedFormula, Scenario, VAFSpectrum, VAFUniverse,
+};
 use crate::utils::log2_fold_change::Log2FoldChangePredicate;
 use crate::variants::model::modes::generic::{LikelihoodOperands, VafLfc};
 use crate::variants::model::AlleleFreq;
@@ -58,6 +61,188 @@ impl<'a> IntoIterator for &'a VAFTree {
     fn into_iter(self) -> Self::IntoIter {
         self.inner.iter()
     }
+}
+
+/// A single conjunctive clause of a `VAFTree`, i.e. one root-to-leaf path. It captures exactly the
+/// set of assignments (per-sample VAF plus variant / log2-fold-change context) for which that path
+/// evaluates to true. The disjunction of all clauses of a tree is the event itself.
+#[derive(Clone, Debug)]
+pub(crate) struct Clause {
+    /// Per-sample VAF constraint. Every sample of the scenario is present on every live path
+    /// (see `VAFTree::new`'s `add_missing_samples`); a sample constrained more than once along the
+    /// path carries the intersection of its constraints.
+    vafs: BTreeMap<usize, VAFSpectrum>,
+    /// Variant terminals (`refbase>altbase`, negated if `positive` is false) required on this path.
+    variants: BTreeSet<(Iupac, Iupac, bool)>,
+    /// Log2-fold-change terminals required on this path.
+    lfcs: BTreeSet<(usize, usize, Log2FoldChangePredicate)>,
+}
+
+impl Clause {
+    fn empty() -> Self {
+        Clause {
+            vafs: BTreeMap::new(),
+            variants: BTreeSet::new(),
+            lfcs: BTreeSet::new(),
+        }
+    }
+}
+
+/// Depth-first enumeration of a node's clauses, extending `acc` with the current node. Paths
+/// through a `False` node or an empty VAF intersection are pruned (they can never be true).
+fn collect_clauses(node: &Node, acc: &Clause, out: &mut Vec<Clause>) {
+    let mut acc = acc.clone();
+    match node.kind() {
+        NodeKind::Sample { sample, vafs } => match acc.vafs.entry(*sample) {
+            Entry::Occupied(mut entry) => {
+                let intersection = entry.get().intersect(vafs);
+                if intersection.is_empty() {
+                    return;
+                }
+                *entry.get_mut() = intersection;
+            }
+            Entry::Vacant(entry) => {
+                if vafs.is_empty() {
+                    return;
+                }
+                entry.insert(vafs.clone());
+            }
+        },
+        NodeKind::Variant {
+            refbase,
+            altbase,
+            positive,
+        } => {
+            acc.variants.insert((*refbase, *altbase, *positive));
+        }
+        NodeKind::Log2FoldChange {
+            sample_a,
+            sample_b,
+            predicate,
+        } => {
+            acc.lfcs.insert((*sample_a, *sample_b, *predicate));
+        }
+        NodeKind::True => {}
+        NodeKind::False => return,
+    }
+
+    if node.is_leaf() {
+        out.push(acc);
+    } else {
+        for child in node.children() {
+            collect_clauses(child, &acc, out);
+        }
+    }
+}
+
+impl VAFTree {
+    /// Enumerate the conjunctive clauses (root-to-leaf paths) of this tree, pruning unsatisfiable
+    /// paths.
+    fn clauses(&self) -> Vec<Clause> {
+        let mut out = Vec::new();
+        let root = Clause::empty();
+        for node in &self.inner {
+            collect_clauses(node, &root, &mut out);
+        }
+        out
+    }
+
+    /// If `self` and `other` are *not* disjoint, return a human-readable witness: a concrete VAF
+    /// assignment (drawn from the universes) together with the shared variant / log2-fold-change
+    /// context for which both events are true simultaneously. Returns `None` if the two events are
+    /// disjoint.
+    ///
+    /// Two clauses can be jointly true only if they impose exactly the same variant and
+    /// log2-fold-change terminals: this matches the model's own containment semantics
+    /// (`VAFTree::contains`), where a leaf is satisfied only when the provided log2-fold-change
+    /// facts are consumed exactly, and where a genomic locus carries a single, definite variant.
+    /// For events that differ only in such terminals this is conservative (it never reports a
+    /// spurious overlap), while for pure allele-frequency events the check is exact and complete.
+    pub(crate) fn overlap_witness(
+        &self,
+        other: &VAFTree,
+        universes: &[(String, VAFUniverse)],
+    ) -> Option<String> {
+        let own = self.clauses();
+        let others = other.clauses();
+        for a in &own {
+            for b in &others {
+                if a.variants != b.variants || a.lfcs != b.lfcs {
+                    continue;
+                }
+                if let Some(witness) = clause_witness(a, b, universes) {
+                    return Some(witness);
+                }
+            }
+        }
+        None
+    }
+}
+
+/// Build a witness for a pair of clauses that share the same variant/lfc context, or `None` if for
+/// some sample the two VAF constraints have no common value within that sample's universe.
+fn clause_witness(a: &Clause, b: &Clause, universes: &[(String, VAFUniverse)]) -> Option<String> {
+    let mut assignment = Vec::with_capacity(universes.len());
+    for (sample, (name, universe)) in universes.iter().enumerate() {
+        // Combine the (possibly absent) constraints of both clauses for this sample.
+        let combined = match (a.vafs.get(&sample), b.vafs.get(&sample)) {
+            (Some(x), Some(y)) => Some(x.intersect(y)),
+            (Some(x), None) => Some(x.clone()),
+            (None, Some(y)) => Some(y.clone()),
+            (None, None) => None,
+        };
+        if let Some(ref spectrum) = combined {
+            if spectrum.is_empty() {
+                return None;
+            }
+        }
+
+        // Clip against the universe (a disjunction of spectra) and pick a representative value. If
+        // no universe value satisfies the combined constraint, this VAF combination can never
+        // occur and the two events do not actually overlap here.
+        let mut universe_specs: Vec<&VAFSpectrum> = universe.iter().collect();
+        universe_specs.sort();
+        let representative = universe_specs.iter().find_map(|u| match &combined {
+            Some(spectrum) => spectrum.intersect(u).representative(),
+            None => u.representative(),
+        })?;
+        assignment.push(format!("{}={}", name, representative));
+    }
+
+    let mut witness = assignment.join(", ");
+    let context = clause_context(a, universes);
+    if !context.is_empty() {
+        witness = format!("{}, {}", witness, context.join(", "));
+    }
+    Some(witness)
+}
+
+/// Human-readable description of the variant and log2-fold-change terminals shared by a clause.
+fn clause_context(clause: &Clause, universes: &[(String, VAFUniverse)]) -> Vec<String> {
+    let name = |idx: usize| {
+        universes
+            .get(idx)
+            .map(|(name, _)| name.clone())
+            .unwrap_or_else(|| format!("sample{}", idx))
+    };
+    let mut context = Vec::new();
+    for (refbase, altbase, positive) in &clause.variants {
+        context.push(format!(
+            "{}({}>{})",
+            if *positive { "" } else { "!" },
+            refbase,
+            altbase
+        ));
+    }
+    for (sample_a, sample_b, predicate) in &clause.lfcs {
+        context.push(format!(
+            "l2fc({}, {}) {}",
+            name(*sample_a),
+            name(*sample_b),
+            predicate
+        ));
+    }
+    context
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/tests/resources/prior/scenarios/pedigree.scenario.yaml
+++ b/tests/resources/prior/scenarios/pedigree.scenario.yaml
@@ -32,6 +32,6 @@ samples:
           - father
 
 events:
-  denovo_child: "(child:0.5 | child:1.0) & mother:0.0 & father:0.0"
-  denovo_sibling: "(sibling:0.5 | sibling:1.0) & mother:0.0 & father:0.0"
+  denovo_child: "(child:0.5 | child:1.0) & sibling:0.0 & mother:0.0 & father:0.0"
+  denovo_sibling: "child:0.0 & (sibling:0.5 | sibling:1.0) & mother:0.0 & father:0.0"
   inherited: "!mother:0.0 | !father:0.0"


### PR DESCRIPTION
## Motivation
The docs require events to be pairwise disjoint — no combination of allele
frequencies may satisfy more than one event, since the generic model treats
events as mutually exclusive when summing posteriors. This was only enforced by
a heuristic in `Scenario::validate` that flagged a pair `(e1, e2)` when
`e1 | e2` happened to equal a third *named* event (with a `TODO` noting it was
unreliable). It misses the documented counter-example: `germline` = `normal:0.5`
overlapping a `somatic_normal` = `normal:]0.0,0.5]`.

## Change
Replace it with an exact per-contig pairwise check over `VAFTree` clauses
(root-to-leaf paths). Two events overlap when some clause pair shares the same
variant and log2-fold-change literals and has a non-empty per-sample VAF
intersection within the declared universe. The `OverlappingEvents` error now
names the offending pair and exhibits a concrete VAF witness, e.g.:

    the following events are not disjunct: "germline" and "somatic_normal" (witness: normal=0.5)

Boolean-terminal handling uses exact set matching: sound (no false positives),
consistent with the model's own `VAFTree::contains` semantics, so events
distinguished only by log2-fold-change predicates or variant terminals stay
disjoint. The check is exact and complete on pure allele-frequency events.

## Tests
- New unit tests: documented counter-example, disjoint tumor/normal, identical
  events, interior-range witness, full overlap fixture, l2fc-disjoint,
  variant-disjoint.
- Integration: `test_overlapping_events` still panics; `test_l2fc`, `test_cmp`,
  `test40/55/57/59` still pass.

## Also
Fixes a latent overlap this check surfaced in
`tests/resources/prior/scenarios/pedigree.scenario.yaml`: `denovo_child` and
`denovo_sibling` were both true at `mother=0, father=0, child=0.5, sibling=0.5`
(each left the other child unconstrained). Each de novo event now requires the
other child to be absent — also the correct semantics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved detection of overlapping genetic events, including compatible variant constraints.
  * Error messages now identify conflicting events and provide concrete example assignments.
  * Added support for frequency-spectrum intersections and representative allele-frequency values.

* **Bug Fixes**
  * Improved scenario validation using sample-specific frequency constraints.
  * Corrected pedigree event expressions to include required cross-individual constraints.
  * Updated a brain event scenario to exclude the midpoint value from matching.

* **Tests**
  * Added regression coverage for overlap detection, witness details, edge-case frequency ranges, and example scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->